### PR TITLE
feat: add Gateway API support, instructions on how to integrate with new Istio charms

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -3,17 +3,20 @@ name: CI
 
 on:
   workflow_call:
-    secrets:
-      CHARMCRAFT_CREDENTIALS:
-        required: true
+# TODO: Uncomment this if we pull this PR into canonical/knative-operators
+#    secrets:
+#      CHARMCRAFT_CREDENTIALS:
+#        required: true
 
 jobs:
-  lib-check:
-    name: Check libraries
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_quality-checks.yaml@main
-    secrets: inherit
-    with:
-        charm-path: "."
+# TODO: Uncomment this if we pull this PR into canonical/knative-operators
+#       Commented so we don't need CHARMCRAFT_CREDENTIALS
+#  lib-check:
+#    name: Check libraries
+#    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_quality-checks.yaml@main
+#    secrets: inherit
+#    with:
+#        charm-path: "."
 
   lint:
     name: Lint Code
@@ -72,38 +75,39 @@ jobs:
       - uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
         if: always()
 
-  integration-observability:
-    name: Observability Integration Test
-    runs-on: ubuntu-20.04
-
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v3
-
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: microk8s
-          channel: 1.26-strict/stable
-          juju-channel: 3.4/stable
-          charmcraft-channel: latest/candidate
-
-      - name: Run integration tests
-        run: |
-          sg snap_microk8s -c "juju add-model cos-test"
-          sg snap_microk8s -c "tox -vve cos-integration -- --model cos-test --destructive-mode"
-
-      - run: kubectl get pod/prometheus-k8s-0 -n knative-test -o=jsonpath='{.status}'
-        if: failure()
-
-      - run: kubectl get pod/knative-operator-0 -nknative-test -o=jsonpath='{.status}'
-        if: failure()
-
-      - run: kubectl get all -A
-        if: failure()
-
-      - run: juju status
-        if: failure()
-
-      - uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
-        if: always()
+# TODO: Uncomment this if we pull this PR into canonical/knative-operators
+#  integration-observability:
+#    name: Observability Integration Test
+#    runs-on: ubuntu-20.04
+#
+#    steps:
+#      - name: Check out repo
+#        uses: actions/checkout@v3
+#
+#      - name: Setup operator environment
+#        uses: charmed-kubernetes/actions-operator@main
+#        with:
+#          provider: microk8s
+#          channel: 1.26-strict/stable
+#          juju-channel: 3.4/stable
+#          charmcraft-channel: latest/candidate
+#
+#      - name: Run integration tests
+#        run: |
+#          sg snap_microk8s -c "juju add-model cos-test"
+#          sg snap_microk8s -c "tox -vve cos-integration -- --model cos-test --destructive-mode"
+#
+#      - run: kubectl get pod/prometheus-k8s-0 -n knative-test -o=jsonpath='{.status}'
+#        if: failure()
+#
+#      - run: kubectl get pod/knative-operator-0 -nknative-test -o=jsonpath='{.status}'
+#        if: failure()
+#
+#      - run: kubectl get all -A
+#        if: failure()
+#
+#      - run: juju status
+#        if: failure()
+#
+#      - uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
+#        if: always()

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -14,8 +14,9 @@ jobs:
     uses: ./.github/workflows/integrate.yaml
     secrets: inherit
 
-  # publish runs in parallel with tests, as we always publish in this situation
-  publish-charm:
-    name: Publish Charm
-    uses: ./.github/workflows/publish.yaml
-    secrets: inherit
+# TODO: Uncomment this if we pull this PR into canonical/knative-operators
+#  # publish runs in parallel with tests, as we always publish in this situation
+#  publish-charm:
+#    name: Publish Charm
+#    uses: ./.github/workflows/publish.yaml
+#    secrets: inherit

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -20,9 +20,10 @@ jobs:
     uses: ./.github/workflows/integrate.yaml
     secrets: inherit
 
-  # publish runs in series with tests, and only publishes if tests passes
-  publish-charm:
-    name: Publish Charm
-    needs: tests
-    uses: ./.github/workflows/publish.yaml
-    secrets: inherit
+# TODO: Uncomment this if we pull this PR into canonical/knative-operators
+#  # publish runs in series with tests, and only publishes if tests passes
+#  publish-charm:
+#    name: Publish Charm
+#    needs: tests
+#    uses: ./.github/workflows/publish.yaml
+#    secrets: inherit

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,94 +1,95 @@
-# reusable workflow for publishing all charms in this repo
-name: Publish
-
-on:
-  workflow_call:
-    inputs:
-      source_branch:
-        description: Github branch from this repo to publish.  If blank, will use the default branch
-        default: ''
-        required: false
-        type: string
-    secrets:
-      CHARMCRAFT_CREDENTIALS:
-        required: true
-  workflow_dispatch:
-    inputs:
-      destination_channel:
-        description: CharmHub channel to publish to
-        required: false
-        default: 'latest/edge'
-        type: string
-      source_branch:
-        description: Github branch from this repo to publish.  If blank, will use the default branch
-        required: false
-        default: ''
-        type: string
-
-jobs:
-  get-charm-paths:
-    name: Generate the Charm Matrix
-    runs-on: ubuntu-20.04
-    outputs:
-      charm_paths_list: ${{ steps.get-charm-paths.outputs.CHARM_PATHS_LIST }}
-    steps:
-      - uses: actions/checkout@v3
-        with: 
-          fetch-depth: 0
-          ref: ${{ inputs.source_branch }}
-      - name: Get paths for all charms in repo
-        id: get-charm-paths
-        run: bash .github/workflows/get-charm-paths.sh
-
-
-  publish-charm:
-    name: Publish Charm
-    runs-on: ubuntu-20.04
-    needs: get-charm-paths
-    strategy:
-      fail-fast: false
-      matrix:
-        charm-path: ${{ fromJson(needs.get-charm-paths.outputs.charm_paths_list) }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          ref: ${{ inputs.source_branch }}
-
-      - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.6.2
-        id: select-channel
-        if: ${{ inputs.destination_channel == '' }}
-
-      # Combine inputs from different sources to a single canonical value so later steps don't
-      # need logic for picking the right one
-      - name: Parse and combine inputs
-        id: parse-inputs
-        run: |
-          # destination_channel
-          destination_channel="${{ inputs.destination_channel || steps.select-channel.outputs.name }}"
-          echo "setting output of destination_channel=$destination_channel"
-          echo "::set-output name=destination_channel::$destination_channel"
-
-          # tag_prefix
-          # if charm_path = ./ --> tag_prefix = '' (null)
-          # if charm_path != ./some-charm (eg: a charm in a ./charms dir) --> tag_prefix = 'some-charm'
-          if [ ${{ matrix.charm-path }} == './' ]; then
-            tag_prefix=''
-          else
-            tag_prefix=$(basename ${{ matrix.charm-path }} )
-          fi
-          echo "setting output of tag_prefix=$tag_prefix"
-          echo "::set-output name=tag_prefix::$tag_prefix"
-
-      - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.6.2
-        with:
-          credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          charm-path: ${{ matrix.charm-path }}
-          channel: ${{ steps.parse-inputs.outputs.destination_channel }}
-          tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
-          charmcraft-channel: latest/candidate
+# TODO: Uncomment this if we pull this PR into canonical/knative-operators
+## reusable workflow for publishing all charms in this repo
+#name: Publish
+#
+#on:
+#  workflow_call:
+#    inputs:
+#      source_branch:
+#        description: Github branch from this repo to publish.  If blank, will use the default branch
+#        default: ''
+#        required: false
+#        type: string
+#    secrets:
+#      CHARMCRAFT_CREDENTIALS:
+#        required: true
+#  workflow_dispatch:
+#    inputs:
+#      destination_channel:
+#        description: CharmHub channel to publish to
+#        required: false
+#        default: 'latest/edge'
+#        type: string
+#      source_branch:
+#        description: Github branch from this repo to publish.  If blank, will use the default branch
+#        required: false
+#        default: ''
+#        type: string
+#
+#jobs:
+#  get-charm-paths:
+#    name: Generate the Charm Matrix
+#    runs-on: ubuntu-20.04
+#    outputs:
+#      charm_paths_list: ${{ steps.get-charm-paths.outputs.CHARM_PATHS_LIST }}
+#    steps:
+#      - uses: actions/checkout@v3
+#        with:
+#          fetch-depth: 0
+#          ref: ${{ inputs.source_branch }}
+#      - name: Get paths for all charms in repo
+#        id: get-charm-paths
+#        run: bash .github/workflows/get-charm-paths.sh
+#
+#
+#  publish-charm:
+#    name: Publish Charm
+#    runs-on: ubuntu-20.04
+#    needs: get-charm-paths
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        charm-path: ${{ fromJson(needs.get-charm-paths.outputs.charm_paths_list) }}
+#
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#        with:
+#          fetch-depth: 0
+#          ref: ${{ inputs.source_branch }}
+#
+#      - name: Select charmhub channel
+#        uses: canonical/charming-actions/channel@2.6.2
+#        id: select-channel
+#        if: ${{ inputs.destination_channel == '' }}
+#
+#      # Combine inputs from different sources to a single canonical value so later steps don't
+#      # need logic for picking the right one
+#      - name: Parse and combine inputs
+#        id: parse-inputs
+#        run: |
+#          # destination_channel
+#          destination_channel="${{ inputs.destination_channel || steps.select-channel.outputs.name }}"
+#          echo "setting output of destination_channel=$destination_channel"
+#          echo "::set-output name=destination_channel::$destination_channel"
+#
+#          # tag_prefix
+#          # if charm_path = ./ --> tag_prefix = '' (null)
+#          # if charm_path != ./some-charm (eg: a charm in a ./charms dir) --> tag_prefix = 'some-charm'
+#          if [ ${{ matrix.charm-path }} == './' ]; then
+#            tag_prefix=''
+#          else
+#            tag_prefix=$(basename ${{ matrix.charm-path }} )
+#          fi
+#          echo "setting output of tag_prefix=$tag_prefix"
+#          echo "::set-output name=tag_prefix::$tag_prefix"
+#
+#      - name: Upload charm to charmhub
+#        uses: canonical/charming-actions/upload-charm@2.6.2
+#        with:
+#          credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+#          github-token: ${{ secrets.GITHUB_TOKEN }}
+#          charm-path: ${{ matrix.charm-path }}
+#          channel: ${{ steps.parse-inputs.outputs.destination_channel }}
+#          tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
+#          charmcraft-channel: latest/candidate

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,31 +1,32 @@
-# reusable workflow triggered manually
-name: Release charm to other tracks and channels
-
-on:
-  workflow_dispatch:
-    inputs:
-      destination-channel:
-        description: 'Destination Channel'
-        required: true
-      origin-channel:
-        description: 'Origin Channel'
-        required: true
-      charm-name:
-        description: 'Charm subdirectory name'
-        required: true
-
-jobs:
-  promote-charm:
-    name: Promote charm
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-      - name: Release charm to channel
-        uses: canonical/charming-actions/release-charm@2.6.2
-        with:
-          credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          destination-channel: ${{ github.event.inputs.destination-channel }}
-          origin-channel: ${{ github.event.inputs.origin-channel }}
-          tag-prefix: ${{ github.event.inputs.charm-name }}
-          charm-path: charms/${{ github.event.inputs.charm-name}}
+# TODO: Uncomment this if we pull this PR into canonical/knative-operators
+## reusable workflow triggered manually
+#name: Release charm to other tracks and channels
+#
+#on:
+#  workflow_dispatch:
+#    inputs:
+#      destination-channel:
+#        description: 'Destination Channel'
+#        required: true
+#      origin-channel:
+#        description: 'Origin Channel'
+#        required: true
+#      charm-name:
+#        description: 'Charm subdirectory name'
+#        required: true
+#
+#jobs:
+#  promote-charm:
+#    name: Promote charm
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Release charm to channel
+#        uses: canonical/charming-actions/release-charm@2.6.2
+#        with:
+#          credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+#          github-token: ${{ secrets.GITHUB_TOKEN }}
+#          destination-channel: ${{ github.event.inputs.destination-channel }}
+#          origin-channel: ${{ github.event.inputs.origin-channel }}
+#          tag-prefix: ${{ github.event.inputs.charm-name }}
+#          charm-path: charms/${{ github.event.inputs.charm-name}}

--- a/charms/knative-eventing/config.yaml
+++ b/charms/knative-eventing/config.yaml
@@ -3,7 +3,7 @@
 
 options:
   version:
-    default: "1.12.4"
+    default: "1.15.2"
     description: Version of knative-eventing component.
     type: string
   namespace:

--- a/charms/knative-operator/metadata.yaml
+++ b/charms/knative-operator/metadata.yaml
@@ -24,8 +24,8 @@ resources:
   knative-operator-image:
     type: oci-image
     description: OCI image for knative-operator
-    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/operator:v1.12.4
+    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/operator@sha256:18e7a0c612efdce11d9d396fa9a1469fa206bdb2a817b5426a595ed57a5c3daf
   knative-operator-webhook-image:
     type: oci-image
     description: OCI image for knative-operator's operator-webhook component
-    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/webhook:v1.12.4
+    upstream-source: gcr.io/knative-releases/knative.dev/operator/cmd/webhook@sha256:dc2b23c9f66869a8617a51f2f0af0f56d9dc6a85b71cff587161eb9711aef26a

--- a/charms/knative-operator/src/charm.py
+++ b/charms/knative-operator/src/charm.py
@@ -159,6 +159,7 @@ class KnativeOperatorCharm(CharmBase):
                         "METRICS_DOMAIN": "knative.dev/operator",
                         "CONFIG_LOGGING_NAME": "config-logging",
                         "CONFIG_OBSERVABILITY_NAME": "config-observability",
+                        "KUBERNETES_MIN_VERSION": "",
                     },
                 }
             },

--- a/charms/knative-operator/src/manifests/config_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/config_manifests.yaml.j2
@@ -18,6 +18,9 @@ kind: ConfigMap
 metadata:
   name: config-logging
   namespace: {{ namespace }}
+  labels:
+    app.kubernetes.io/version: "1.15.1"
+    app.kubernetes.io/name: knative-operator
 data:
   _example: |
     ################################
@@ -79,6 +82,9 @@ kind: ConfigMap
 metadata:
   name: config-observability
   namespace: {{ namespace }}
+  labels:
+    app.kubernetes.io/version: "1.15.1"
+    app.kubernetes.io/name: knative-operator
 data:
   _example: |
     ################################
@@ -107,35 +113,6 @@ data:
     # access to Kibana after setting up kubectl proxy.
     logging.revision-url-template: |
       http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.serving-knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))
-
-    # If non-empty, this enables queue proxy writing request logs to stdout.
-    # The value determines the shape of the request logs and it must be a valid go text/template.
-    # It is important to keep this as a single line. Multiple lines are parsed as separate entities
-    # by most collection agents and will split the request logs into multiple records.
-    #
-    # The following fields and functions are available to the template:
-    #
-    # Request: An http.Request (see https://golang.org/pkg/net/http/#Request)
-    # representing an HTTP request received by the server.
-    #
-    # Response:
-    # struct {
-    #   Code    int       // HTTP status code (see https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)
-    #   Size    int       // An int representing the size of the response.
-    #   Latency float64   // A float64 representing the latency of the response in seconds.
-    # }
-    #
-    # Revision:
-    # struct {
-    #   Name          string  // Knative revision name
-    #   Namespace     string  // Knative revision namespace
-    #   Service       string  // Knative service name
-    #   Configuration string  // Knative configuration name
-    #   PodName       string  // Name of the pod hosting the revision
-    #   PodIP         string  // IP of the pod hosting the revision
-    # }
-    #
-    logging.request-log-template: <<Example removed because it messes with charmed kubeflow's templating.  See upstream's yaml for example of this setting>>
 
     # metrics.backend-destination field specifies the system metrics destination.
     # It supports either prometheus (the default) or stackdriver.

--- a/charms/knative-operator/src/manifests/crds_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/crds_manifests.yaml.j2
@@ -1,2451 +1,4 @@
-# Source: knative/operator/config/crd/bases/operator.knative.dev_knativeservings.yaml
-# Copyright 2021 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: knativeservings.operator.knative.dev
-spec:
-  group: operator.knative.dev
-  versions:
-  - name: v1beta1
-    served: true
-    storage: true
-    subresources:
-      status: {}
-    schema:
-      openAPIV3Schema:
-        description: Schema for the knativeservings API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec defines the desired state of KnativeServing
-            properties:
-              additionalManifests:
-                description: A list of the additional serving manifests, which will
-                  be installed by the operator
-                items:
-                  properties:
-                    URL:
-                      description: The link of the additional manifest URL
-                      type: string
-                  type: object
-                type: array
-              config:
-                additionalProperties:
-                  additionalProperties:
-                    type: string
-                  type: object
-                description: A means to override the corresponding entries in the
-                  upstream configmaps
-                type: object
-              controller-custom-certs:
-                description: Enabling the controller to trust registries with self-signed
-                  certificates
-                properties:
-                  name:
-                    description: The name of the ConfigMap or Secret
-                    type: string
-                  type:
-                    description: One of ConfigMap or Secret
-                    enum:
-                    - ConfigMap
-                    - Secret
-                    - ""
-                    type: string
-                type: object
-              high-availability:
-                description: Allows specification of HA control plane
-                properties:
-                  replicas:
-                    description: The number of replicas that HA parts of the control
-                      plane will be scaled to
-                    minimum: 0
-                    type: integer
-                type: object
-              workloads:
-                description: A mapping of deployment or statefulset name to override
-                type: array
-                items:
-                  type: object
-                  properties:
-                    name:
-                      description: The name of the deployment
-                      type: string
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: Labels overrides labels for the deployment and its template.
-                      type: object
-                    livenessProbes:
-                      description: LivenessProbes overrides liveness probes for the
-                        containers.
-                      items:
-                        description: ProbesRequirementsOverride enables the user to
-                          override any container's env vars.
-                        properties:
-                          container:
-                            description: The container name
-                            type: string
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully upon probe failure. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and
-                              the time when the processes are forcibly halted with
-                              a kill signal. Set this value longer than the expected
-                              cleanup time for your process. If this value is nil,
-                              the pod's terminationGracePeriodSeconds will be used.
-                              Otherwise, this value overrides the value provided by
-                              the pod spec. Value must be non-negative integer. The
-                              value zero indicates stop immediately via the kill signal
-                              (no opportunity to shut down). This is a beta field
-                              and requires enabling ProbeTerminationGracePeriod feature
-                              gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                              is used if unset.
-                            format: int64
-                            type: integer
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                            times out. Defaults to 1 second. Minimum value is 1.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        required:
-                          - container
-                        type: object
-                      type: array
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations overrides labels for the deployment and its template.
-                      type: object
-                    env:
-                      description: Env overrides env vars for the containers.
-                      items:
-                        properties:
-                          container:
-                            description: The container name
-                            type: string
-                          envVars:
-                            description: The desired EnvVarRequirements
-                            items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
-                              properties:
-                                name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
-                                  type: string
-                                value:
-                                  description: 'Variable references $(VAR_NAME) are
-                                    expanded using the previously defined environment
-                                    variables in the container and any service environment
-                                    variables. If a variable cannot be resolved, the
-                                    reference in the input string will be unchanged.
-                                    Double $$ are reduced to a single $, which allows
-                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                    will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Defaults
-                                    to "".'
-                                  type: string
-                                valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
-                                  properties:
-                                    configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
-                                      properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                        - key
-                                      type: object
-                                    fieldRef:
-                                      description: 'Selects a field of the pod: supports
-                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                        spec.serviceAccountName, status.hostIP, status.podIP,
-                                        status.podIPs.'
-                                      properties:
-                                        apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
-                                          type: string
-                                        fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
-                                          type: string
-                                      required:
-                                        - fieldPath
-                                      type: object
-                                    resourceFieldRef:
-                                      description: 'Selects a resource of the container:
-                                        only resources limits and requests (limits.cpu,
-                                        limits.memory, limits.ephemeral-storage, requests.cpu,
-                                        requests.memory and requests.ephemeral-storage)
-                                        are currently supported.'
-                                      properties:
-                                        containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          description: 'Required: resource to select'
-                                          type: string
-                                      required:
-                                        - resource
-                                      type: object
-                                    secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                        - key
-                                      type: object
-                                  type: object
-                              required:
-                                - name
-                              type: object
-                            type: array
-                        required:
-                          - container
-                        type: object
-                      type: array
-                    replicas:
-                      description: The number of replicas that HA parts of the control plane will be scaled to
-                      type: integer
-                      minimum: 0
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: NodeSelector overrides nodeSelector for the deployment.
-                      type: object
-                    readinessProbes:
-                      description: ReadinessProbes overrides readiness probes for
-                        the containers.
-                      items:
-                        description: ProbesRequirementsOverride enables the user to
-                          override any container's env vars.
-                        properties:
-                          container:
-                            description: The container name
-                            type: string
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully upon probe failure. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and
-                              the time when the processes are forcibly halted with
-                              a kill signal. Set this value longer than the expected
-                              cleanup time for your process. If this value is nil,
-                              the pod's terminationGracePeriodSeconds will be used.
-                              Otherwise, this value overrides the value provided by
-                              the pod spec. Value must be non-negative integer. The
-                              value zero indicates stop immediately via the kill signal
-                              (no opportunity to shut down). This is a beta field
-                              and requires enabling ProbeTerminationGracePeriod feature
-                              gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                              is used if unset.
-                            format: int64
-                            type: integer
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                            times out. Defaults to 1 second. Minimum value is 1.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        required:
-                          - container
-                        type: object
-                      type: array
-                    tolerations:
-                      description: If specified, the pod's tolerations.
-                      items:
-                        description: The pod this Toleration is attached to tolerates any
-                          taint that matches the triple <key,value,effect> using the matching
-                          operator <operator>.
-                        properties:
-                          effect:
-                            description: Effect indicates the taint effect to match. Empty
-                              means match all taint effects. When specified, allowed values
-                              are NoSchedule, PreferNoSchedule and NoExecute.
-                            type: string
-                          key:
-                            description: Key is the taint key that the toleration applies
-                              to. Empty means match all taint keys. If the key is empty, operator
-                              must be Exists; this combination means to match all values and
-                              all keys.
-                            type: string
-                          operator:
-                            description: Operator represents a key's relationship to the value.
-                              Valid operators are Exists and Equal. Defaults to Equal. Exists
-                              is equivalent to wildcard for value, so that a pod can tolerate
-                              all taints of a particular category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the
-                              toleration (which must be of effect NoExecute, otherwise this
-                              field is ignored) tolerates the taint. By default, it is not
-                              set, which means tolerate the taint forever (do not evict).
-                              Zero and negative values will be treated as 0 (evict immediately)
-                              by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches to.
-                              If the operator is Exists, the value should be empty, otherwise
-                              just a regular string.
-                            type: string
-                        type: object
-                      type: array
-                    hostNetwork:
-                      description: Use the host's network namespace if true. Make sure to
-                        understand the security implications if you want to enable it. When
-                        hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet
-                        automatically.
-                      type: boolean
-                    topologySpreadConstraints:
-                      description: If specified, the pod's topology spread constraints.
-                      items:
-                        description: TopologySpreadConstraint specifies how to spread matching
-                          pods among the given topology.
-                        properties:
-                          labelSelector:
-                            description: LabelSelector is used to find matching pods. Pods
-                              that match this label selector are counted to determine the
-                              number of pods in their corresponding topology domain.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that relates
-                                    the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In, NotIn,
-                                        Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists or
-                                        DoesNotExist, the values array must be empty. This
-                                        array is replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field is
-                                  "key", the operator is "In", and the values array contains
-                                  only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          maxSkew:
-                            description: 'MaxSkew describes the degree to which pods may
-                              be unevenly distributed. It''s the maximum permitted difference
-                              between the number of matching pods in any two topology domains
-                              of a given topology type. For example, in a 3-zone cluster,
-                              MaxSkew is set to 1, and pods with the same labelSelector
-                              spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3
-                              to become 1/1/1; scheduling it onto zone1(zone2) would make
-                              the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). -
-                              if MaxSkew is 2, incoming pod can be scheduled onto any zone.
-                              It''s a required field. Default value is 1 and 0 is not allowed.'
-                            format: int32
-                            type: integer
-                          topologyKey:
-                            description: TopologyKey is the key of node labels. Nodes that
-                              have a label with this key and identical values are considered
-                              to be in the same topology. We consider each <key, value>
-                              as a "bucket", and try to put balanced number of pods into
-                              each bucket. It's a required field.
-                            type: string
-                          whenUnsatisfiable:
-                            description: 'WhenUnsatisfiable indicates how to deal with a
-                              pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
-                              (default) tells the scheduler not to schedule it - ScheduleAnyway
-                              tells the scheduler to still schedule it It''s considered
-                              as "Unsatisfiable" if and only if placing incoming pod on
-                              any topology violates "MaxSkew". For example, in a 3-zone
-                              cluster, MaxSkew is set to 1, and pods with the same labelSelector
-                              spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
-                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod
-                              can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
-                              as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In
-                              other words, the cluster can still be imbalanced, but scheduler
-                              won''t make it *more* imbalanced. It''s a required field.'
-                            type: string
-                        required:
-                        - maxSkew
-                        - topologyKey
-                        - whenUnsatisfiable
-                        type: object
-                      type: array
-                    version:
-                      description: Version the cluster should be on.
-                      type: string
-                    volumeMounts:
-                      description: VolumeMounts allows configuration of additional VolumeMounts
-                        on the output StatefulSet definition. VolumeMounts specified will
-                        be appended to other VolumeMounts in the alertmanager container,
-                        that are generated as a result of StorageSpec objects.
-                      items:
-                        description: VolumeMount describes a mounting of a Volume within
-                          a container.
-                        properties:
-                          mountPath:
-                            description: Path within the container at which the volume should
-                              be mounted.  Must not contain ':'.
-                            type: string
-                          mountPropagation:
-                            description: mountPropagation determines how mounts are propagated
-                              from the host to container and the other way around. When
-                              not set, MountPropagationNone is used. This field is beta
-                              in 1.10.
-                            type: string
-                          name:
-                            description: This must match the Name of a Volume.
-                            type: string
-                          readOnly:
-                            description: Mounted read-only if true, read-write otherwise
-                              (false or unspecified). Defaults to false.
-                            type: boolean
-                          subPath:
-                            description: Path within the volume from which the container's
-                              volume should be mounted. Defaults to "" (volume's root).
-                            type: string
-                          subPathExpr:
-                            description: Expanded path within the volume from which the
-                              container's volume should be mounted. Behaves similarly to
-                              SubPath but environment variable references $(VAR_NAME) are
-                              expanded using the container's environment. Defaults to ""
-                              (volume's root). SubPathExpr and SubPath are mutually exclusive.
-                            type: string
-                        required:
-                        - mountPath
-                        - name
-                        type: object
-                      type: array
-                    affinity:
-                      description: If specified, the pod's scheduling constraints.
-                      properties:
-                        nodeAffinity:
-                          description: Describes node affinity scheduling rules for the pod.
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes
-                                that satisfy the affinity expressions specified by this field,
-                                but it may choose a node that violates one or more of the
-                                expressions. The node that is most preferred is the one with
-                                the greatest sum of weights, i.e. for each node that meets
-                                all of the scheduling requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating through
-                                the elements of this field and adding "weight" to the sum
-                                if the node matches the corresponding matchExpressions; the
-                                node(s) with the highest sum are the most preferred.
-                              items:
-                                description: An empty preferred scheduling term matches all
-                                  objects with implicit weight 0 (i.e. it's a no-op). A null
-                                  preferred scheduling term matches no objects (i.e. is also
-                                  a no-op).
-                                properties:
-                                  preference:
-                                    description: A node selector term, associated with the
-                                      corresponding weight.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values. If the
-                                                operator is In or NotIn, the values array
-                                                must be non-empty. If the operator is Exists
-                                                or DoesNotExist, the values array must be
-                                                empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will
-                                                be interpreted as an integer. This array is
-                                                replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values. If the
-                                                operator is In or NotIn, the values array
-                                                must be non-empty. If the operator is Exists
-                                                or DoesNotExist, the values array must be
-                                                empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will
-                                                be interpreted as an integer. This array is
-                                                replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  weight:
-                                    description: Weight associated with matching the corresponding
-                                      nodeSelectorTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - preference
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this
-                                field are not met at scheduling time, the pod will not be
-                                scheduled onto the node. If the affinity requirements specified
-                                by this field cease to be met at some point during pod execution
-                                (e.g. due to an update), the system may or may not try to
-                                eventually evict the pod from its node.
-                              properties:
-                                nodeSelectorTerms:
-                                  description: Required. A list of node selector terms. The
-                                    terms are ORed.
-                                  items:
-                                    description: A null or empty node selector term matches
-                                      no objects. The requirements of them are ANDed. The
-                                      TopologySelectorTerm type implements a subset of the
-                                      NodeSelectorTerm.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values. If the
-                                                operator is In or NotIn, the values array
-                                                must be non-empty. If the operator is Exists
-                                                or DoesNotExist, the values array must be
-                                                empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will
-                                                be interpreted as an integer. This array is
-                                                replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values. If the
-                                                operator is In or NotIn, the values array
-                                                must be non-empty. If the operator is Exists
-                                                or DoesNotExist, the values array must be
-                                                empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will
-                                                be interpreted as an integer. This array is
-                                                replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  type: array
-                              required:
-                                - nodeSelectorTerms
-                              type: object
-                          type: object
-                        podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g. co-locate
-                            this pod in the same node, zone, etc. as some other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes
-                                that satisfy the affinity expressions specified by this field,
-                                but it may choose a node that violates one or more of the
-                                expressions. The node that is most preferred is the one with
-                                the greatest sum of weights, i.e. for each node that meets
-                                all of the scheduling requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating through
-                                the elements of this field and adding "weight" to the sum
-                                if the node has pods which matches the corresponding podAffinityTerm;
-                                the node(s) with the highest sum are the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement is
-                                                a selector that contains values, a key, and
-                                                an operator that relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that the
-                                                    selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If
-                                                    the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array
-                                                    is replaced during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is "In",
-                                              and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey matches
-                                          that of any node on which any of the selected pods
-                                          is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the corresponding
-                                      podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this
-                                field are not met at scheduling time, the pod will not be
-                                scheduled onto the node. If the affinity requirements specified
-                                by this field cease to be met at some point during pod execution
-                                (e.g. due to a pod label update), the system may or may not
-                                try to eventually evict the pod from its node. When there
-                                are multiple elements, the lists of nodes corresponding to
-                                each podAffinityTerm are intersected, i.e. all terms must
-                                be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s)) that
-                                  this pod should be co-located (affinity) or not co-located
-                                  (anti-affinity) with, where co-located is defined as running
-                                  on a node whose value of the label with key <topologyKey>
-                                  matches that of any node on which a pod of the set of pods
-                                  is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources, in
-                                      this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector
-                                          requirements. The requirements are ANDed.
-                                        items:
-                                          description: A label selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string values.
-                                                If the operator is In or NotIn, the values
-                                                array must be non-empty. If the operator is
-                                                Exists or DoesNotExist, the values array must
-                                                be empty. This array is replaced during a
-                                                strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value} pairs.
-                                          A single {key,value} in the matchLabels map is equivalent
-                                          to an element of matchExpressions, whose key field
-                                          is "key", the operator is "In", and the values array
-                                          contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces the
-                                      labelSelector applies to (matches against); null or
-                                      empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods matching
-                                      the labelSelector in the specified namespaces, where
-                                      co-located is defined as running on a node whose value
-                                      of the label with key topologyKey matches that of any
-                                      node on which any of the selected pods is running. Empty
-                                      topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                        podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules (e.g.
-                            avoid putting this pod in the same node, zone, etc. as some other
-                            pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes
-                                that satisfy the anti-affinity expressions specified by this
-                                field, but it may choose a node that violates one or more
-                                of the expressions. The node that is most preferred is the
-                                one with the greatest sum of weights, i.e. for each node that
-                                meets all of the scheduling requirements (resource request,
-                                requiredDuringScheduling anti-affinity expressions, etc.),
-                                compute a sum by iterating through the elements of this field
-                                and adding "weight" to the sum if the node has pods which
-                                matches the corresponding podAffinityTerm; the node(s) with
-                                the highest sum are the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement is
-                                                a selector that contains values, a key, and
-                                                an operator that relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that the
-                                                    selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If
-                                                    the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array
-                                                    is replaced during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is "In",
-                                              and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey matches
-                                          that of any node on which any of the selected pods
-                                          is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the corresponding
-                                      podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified by
-                                this field are not met at scheduling time, the pod will not
-                                be scheduled onto the node. If the anti-affinity requirements
-                                specified by this field cease to be met at some point during
-                                pod execution (e.g. due to a pod label update), the system
-                                may or may not try to eventually evict the pod from its node.
-                                When there are multiple elements, the lists of nodes corresponding
-                                to each podAffinityTerm are intersected, i.e. all terms must
-                                be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s)) that
-                                  this pod should be co-located (affinity) or not co-located
-                                  (anti-affinity) with, where co-located is defined as running
-                                  on a node whose value of the label with key <topologyKey>
-                                  matches that of any node on which a pod of the set of pods
-                                  is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources, in
-                                      this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector
-                                          requirements. The requirements are ANDed.
-                                        items:
-                                          description: A label selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string values.
-                                                If the operator is In or NotIn, the values
-                                                array must be non-empty. If the operator is
-                                                Exists or DoesNotExist, the values array must
-                                                be empty. This array is replaced during a
-                                                strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value} pairs.
-                                          A single {key,value} in the matchLabels map is equivalent
-                                          to an element of matchExpressions, whose key field
-                                          is "key", the operator is "In", and the values array
-                                          contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces the
-                                      labelSelector applies to (matches against); null or
-                                      empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods matching
-                                      the labelSelector in the specified namespaces, where
-                                      co-located is defined as running on a node whose value
-                                      of the label with key topologyKey matches that of any
-                                      node on which any of the selected pods is running. Empty
-                                      topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                      type: object
-                    resources:
-                      description: If specified, the container's resources.
-                      items:
-                        description: The pod this Resource is used to specify the requests and limits for
-                          a certain container based on the name.
-                        properties:
-                          container:
-                            description: The name of the container
-                            type: string
-                          limits:
-                            properties:
-                              cpu:
-                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                                type: string
-                              memory:
-                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                                type: string
-                            type: object
-                          requests:
-                            properties:
-                              cpu:
-                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                                type: string
-                              memory:
-                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                                type: string
-                            type: object
-                        type: object
-                      type: array
-              deployments:
-                description: A mapping of deployment name to override
-                type: array
-                items:
-                  type: object
-                  properties:
-                    name:
-                      description: The name of the deployment
-                      type: string
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: Labels overrides labels for the deployment and its template.
-                      type: object
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations overrides labels for the deployment and its template.
-                      type: object
-                    env:
-                      description: Env overrides env vars for the containers.
-                      items:
-                        properties:
-                          container:
-                            description: The container name
-                            type: string
-                          envVars:
-                            description: The desired EnvVarRequirements
-                            items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
-                              properties:
-                                name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
-                                  type: string
-                                value:
-                                  description: 'Variable references $(VAR_NAME) are
-                                    expanded using the previously defined environment
-                                    variables in the container and any service environment
-                                    variables. If a variable cannot be resolved, the
-                                    reference in the input string will be unchanged.
-                                    Double $$ are reduced to a single $, which allows
-                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                    will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Defaults
-                                    to "".'
-                                  type: string
-                                valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
-                                  properties:
-                                    configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
-                                      properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                        - key
-                                      type: object
-                                    fieldRef:
-                                      description: 'Selects a field of the pod: supports
-                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                        spec.serviceAccountName, status.hostIP, status.podIP,
-                                        status.podIPs.'
-                                      properties:
-                                        apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
-                                          type: string
-                                        fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
-                                          type: string
-                                      required:
-                                        - fieldPath
-                                      type: object
-                                    resourceFieldRef:
-                                      description: 'Selects a resource of the container:
-                                        only resources limits and requests (limits.cpu,
-                                        limits.memory, limits.ephemeral-storage, requests.cpu,
-                                        requests.memory and requests.ephemeral-storage)
-                                        are currently supported.'
-                                      properties:
-                                        containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          description: 'Required: resource to select'
-                                          type: string
-                                      required:
-                                        - resource
-                                      type: object
-                                    secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                        - key
-                                      type: object
-                                  type: object
-                              required:
-                                - name
-                              type: object
-                            type: array
-                        required:
-                          - container
-                        type: object
-                      type: array
-                    livenessProbes:
-                      description: LivenessProbes overrides liveness probes for the
-                        containers.
-                      items:
-                        description: ProbesRequirementsOverride enables the user to
-                          override any container's env vars.
-                        properties:
-                          container:
-                            description: The container name
-                            type: string
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully upon probe failure. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and
-                              the time when the processes are forcibly halted with
-                              a kill signal. Set this value longer than the expected
-                              cleanup time for your process. If this value is nil,
-                              the pod's terminationGracePeriodSeconds will be used.
-                              Otherwise, this value overrides the value provided by
-                              the pod spec. Value must be non-negative integer. The
-                              value zero indicates stop immediately via the kill signal
-                              (no opportunity to shut down). This is a beta field
-                              and requires enabling ProbeTerminationGracePeriod feature
-                              gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                              is used if unset.
-                            format: int64
-                            type: integer
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                            times out. Defaults to 1 second. Minimum value is 1.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        required:
-                          - container
-                        type: object
-                      type: array
-                    replicas:
-                      description: The number of replicas that HA parts of the control plane will be scaled to
-                      type: integer
-                      minimum: 0
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: NodeSelector overrides nodeSelector for the deployment.
-                      type: object
-                    readinessProbes:
-                      description: ReadinessProbes overrides readiness probes for
-                        the containers.
-                      items:
-                        description: ProbesRequirementsOverride enables the user to
-                          override any container's env vars.
-                        properties:
-                          container:
-                            description: The container name
-                            type: string
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully upon probe failure. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and
-                              the time when the processes are forcibly halted with
-                              a kill signal. Set this value longer than the expected
-                              cleanup time for your process. If this value is nil,
-                              the pod's terminationGracePeriodSeconds will be used.
-                              Otherwise, this value overrides the value provided by
-                              the pod spec. Value must be non-negative integer. The
-                              value zero indicates stop immediately via the kill signal
-                              (no opportunity to shut down). This is a beta field
-                              and requires enabling ProbeTerminationGracePeriod feature
-                              gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                              is used if unset.
-                            format: int64
-                            type: integer
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                            times out. Defaults to 1 second. Minimum value is 1.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        required:
-                          - container
-                        type: object
-                      type: array
-                    tolerations:
-                      description: If specified, the pod's tolerations.
-                      items:
-                        description: The pod this Toleration is attached to tolerates any
-                          taint that matches the triple <key,value,effect> using the matching
-                          operator <operator>.
-                        properties:
-                          effect:
-                            description: Effect indicates the taint effect to match. Empty
-                              means match all taint effects. When specified, allowed values
-                              are NoSchedule, PreferNoSchedule and NoExecute.
-                            type: string
-                          key:
-                            description: Key is the taint key that the toleration applies
-                              to. Empty means match all taint keys. If the key is empty, operator
-                              must be Exists; this combination means to match all values and
-                              all keys.
-                            type: string
-                          operator:
-                            description: Operator represents a key's relationship to the value.
-                              Valid operators are Exists and Equal. Defaults to Equal. Exists
-                              is equivalent to wildcard for value, so that a pod can tolerate
-                              all taints of a particular category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the
-                              toleration (which must be of effect NoExecute, otherwise this
-                              field is ignored) tolerates the taint. By default, it is not
-                              set, which means tolerate the taint forever (do not evict).
-                              Zero and negative values will be treated as 0 (evict immediately)
-                              by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches to.
-                              If the operator is Exists, the value should be empty, otherwise
-                              just a regular string.
-                            type: string
-                        type: object
-                      type: array
-                    hostNetwork:
-                      description: Use the host's network namespace if true. Make sure to
-                        understand the security implications if you want to enable it. When
-                        hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet
-                        automatically.
-                      type: boolean
-                    topologySpreadConstraints:
-                      description: If specified, the pod's topology spread constraints.
-                      items:
-                        description: TopologySpreadConstraint specifies how to spread matching
-                          pods among the given topology.
-                        properties:
-                          labelSelector:
-                            description: LabelSelector is used to find matching pods. Pods
-                              that match this label selector are counted to determine the
-                              number of pods in their corresponding topology domain.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that relates
-                                    the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In, NotIn,
-                                        Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists or
-                                        DoesNotExist, the values array must be empty. This
-                                        array is replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field is
-                                  "key", the operator is "In", and the values array contains
-                                  only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          maxSkew:
-                            description: 'MaxSkew describes the degree to which pods may
-                              be unevenly distributed. It''s the maximum permitted difference
-                              between the number of matching pods in any two topology domains
-                              of a given topology type. For example, in a 3-zone cluster,
-                              MaxSkew is set to 1, and pods with the same labelSelector
-                              spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3
-                              to become 1/1/1; scheduling it onto zone1(zone2) would make
-                              the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). -
-                              if MaxSkew is 2, incoming pod can be scheduled onto any zone.
-                              It''s a required field. Default value is 1 and 0 is not allowed.'
-                            format: int32
-                            type: integer
-                          topologyKey:
-                            description: TopologyKey is the key of node labels. Nodes that
-                              have a label with this key and identical values are considered
-                              to be in the same topology. We consider each <key, value>
-                              as a "bucket", and try to put balanced number of pods into
-                              each bucket. It's a required field.
-                            type: string
-                          whenUnsatisfiable:
-                            description: 'WhenUnsatisfiable indicates how to deal with a
-                              pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
-                              (default) tells the scheduler not to schedule it - ScheduleAnyway
-                              tells the scheduler to still schedule it It''s considered
-                              as "Unsatisfiable" if and only if placing incoming pod on
-                              any topology violates "MaxSkew". For example, in a 3-zone
-                              cluster, MaxSkew is set to 1, and pods with the same labelSelector
-                              spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
-                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod
-                              can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
-                              as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In
-                              other words, the cluster can still be imbalanced, but scheduler
-                              won''t make it *more* imbalanced. It''s a required field.'
-                            type: string
-                        required:
-                        - maxSkew
-                        - topologyKey
-                        - whenUnsatisfiable
-                        type: object
-                      type: array
-                    affinity:
-                      description: If specified, the pod's scheduling constraints.
-                      properties:
-                        nodeAffinity:
-                          description: Describes node affinity scheduling rules for the pod.
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes
-                                that satisfy the affinity expressions specified by this field,
-                                but it may choose a node that violates one or more of the
-                                expressions. The node that is most preferred is the one with
-                                the greatest sum of weights, i.e. for each node that meets
-                                all of the scheduling requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating through
-                                the elements of this field and adding "weight" to the sum
-                                if the node matches the corresponding matchExpressions; the
-                                node(s) with the highest sum are the most preferred.
-                              items:
-                                description: An empty preferred scheduling term matches all
-                                  objects with implicit weight 0 (i.e. it's a no-op). A null
-                                  preferred scheduling term matches no objects (i.e. is also
-                                  a no-op).
-                                properties:
-                                  preference:
-                                    description: A node selector term, associated with the
-                                      corresponding weight.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values. If the
-                                                operator is In or NotIn, the values array
-                                                must be non-empty. If the operator is Exists
-                                                or DoesNotExist, the values array must be
-                                                empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will
-                                                be interpreted as an integer. This array is
-                                                replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values. If the
-                                                operator is In or NotIn, the values array
-                                                must be non-empty. If the operator is Exists
-                                                or DoesNotExist, the values array must be
-                                                empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will
-                                                be interpreted as an integer. This array is
-                                                replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  weight:
-                                    description: Weight associated with matching the corresponding
-                                      nodeSelectorTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                - preference
-                                - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this
-                                field are not met at scheduling time, the pod will not be
-                                scheduled onto the node. If the affinity requirements specified
-                                by this field cease to be met at some point during pod execution
-                                (e.g. due to an update), the system may or may not try to
-                                eventually evict the pod from its node.
-                              properties:
-                                nodeSelectorTerms:
-                                  description: Required. A list of node selector terms. The
-                                    terms are ORed.
-                                  items:
-                                    description: A null or empty node selector term matches
-                                      no objects. The requirements of them are ANDed. The
-                                      TopologySelectorTerm type implements a subset of the
-                                      NodeSelectorTerm.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values. If the
-                                                operator is In or NotIn, the values array
-                                                must be non-empty. If the operator is Exists
-                                                or DoesNotExist, the values array must be
-                                                empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will
-                                                be interpreted as an integer. This array is
-                                                replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values. If the
-                                                operator is In or NotIn, the values array
-                                                must be non-empty. If the operator is Exists
-                                                or DoesNotExist, the values array must be
-                                                empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will
-                                                be interpreted as an integer. This array is
-                                                replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  type: array
-                              required:
-                              - nodeSelectorTerms
-                              type: object
-                          type: object
-                        podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g. co-locate
-                            this pod in the same node, zone, etc. as some other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes
-                                that satisfy the affinity expressions specified by this field,
-                                but it may choose a node that violates one or more of the
-                                expressions. The node that is most preferred is the one with
-                                the greatest sum of weights, i.e. for each node that meets
-                                all of the scheduling requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating through
-                                the elements of this field and adding "weight" to the sum
-                                if the node has pods which matches the corresponding podAffinityTerm;
-                                the node(s) with the highest sum are the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement is
-                                                a selector that contains values, a key, and
-                                                an operator that relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that the
-                                                    selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If
-                                                    the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array
-                                                    is replaced during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is "In",
-                                              and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey matches
-                                          that of any node on which any of the selected pods
-                                          is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                    - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the corresponding
-                                      podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                - podAffinityTerm
-                                - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this
-                                field are not met at scheduling time, the pod will not be
-                                scheduled onto the node. If the affinity requirements specified
-                                by this field cease to be met at some point during pod execution
-                                (e.g. due to a pod label update), the system may or may not
-                                try to eventually evict the pod from its node. When there
-                                are multiple elements, the lists of nodes corresponding to
-                                each podAffinityTerm are intersected, i.e. all terms must
-                                be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s)) that
-                                  this pod should be co-located (affinity) or not co-located
-                                  (anti-affinity) with, where co-located is defined as running
-                                  on a node whose value of the label with key <topologyKey>
-                                  matches that of any node on which a pod of the set of pods
-                                  is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources, in
-                                      this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector
-                                          requirements. The requirements are ANDed.
-                                        items:
-                                          description: A label selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string values.
-                                                If the operator is In or NotIn, the values
-                                                array must be non-empty. If the operator is
-                                                Exists or DoesNotExist, the values array must
-                                                be empty. This array is replaced during a
-                                                strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value} pairs.
-                                          A single {key,value} in the matchLabels map is equivalent
-                                          to an element of matchExpressions, whose key field
-                                          is "key", the operator is "In", and the values array
-                                          contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces the
-                                      labelSelector applies to (matches against); null or
-                                      empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods matching
-                                      the labelSelector in the specified namespaces, where
-                                      co-located is defined as running on a node whose value
-                                      of the label with key topologyKey matches that of any
-                                      node on which any of the selected pods is running. Empty
-                                      topologyKey is not allowed.
-                                    type: string
-                                required:
-                                - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                        podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules (e.g.
-                            avoid putting this pod in the same node, zone, etc. as some other
-                            pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes
-                                that satisfy the anti-affinity expressions specified by this
-                                field, but it may choose a node that violates one or more
-                                of the expressions. The node that is most preferred is the
-                                one with the greatest sum of weights, i.e. for each node that
-                                meets all of the scheduling requirements (resource request,
-                                requiredDuringScheduling anti-affinity expressions, etc.),
-                                compute a sum by iterating through the elements of this field
-                                and adding "weight" to the sum if the node has pods which
-                                matches the corresponding podAffinityTerm; the node(s) with
-                                the highest sum are the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement is
-                                                a selector that contains values, a key, and
-                                                an operator that relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that the
-                                                    selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If
-                                                    the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array
-                                                    is replaced during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is "In",
-                                              and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey matches
-                                          that of any node on which any of the selected pods
-                                          is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                    - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the corresponding
-                                      podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                - podAffinityTerm
-                                - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified by
-                                this field are not met at scheduling time, the pod will not
-                                be scheduled onto the node. If the anti-affinity requirements
-                                specified by this field cease to be met at some point during
-                                pod execution (e.g. due to a pod label update), the system
-                                may or may not try to eventually evict the pod from its node.
-                                When there are multiple elements, the lists of nodes corresponding
-                                to each podAffinityTerm are intersected, i.e. all terms must
-                                be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s)) that
-                                  this pod should be co-located (affinity) or not co-located
-                                  (anti-affinity) with, where co-located is defined as running
-                                  on a node whose value of the label with key <topologyKey>
-                                  matches that of any node on which a pod of the set of pods
-                                  is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources, in
-                                      this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector
-                                          requirements. The requirements are ANDed.
-                                        items:
-                                          description: A label selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string values.
-                                                If the operator is In or NotIn, the values
-                                                array must be non-empty. If the operator is
-                                                Exists or DoesNotExist, the values array must
-                                                be empty. This array is replaced during a
-                                                strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value} pairs.
-                                          A single {key,value} in the matchLabels map is equivalent
-                                          to an element of matchExpressions, whose key field
-                                          is "key", the operator is "In", and the values array
-                                          contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces the
-                                      labelSelector applies to (matches against); null or
-                                      empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods matching
-                                      the labelSelector in the specified namespaces, where
-                                      co-located is defined as running on a node whose value
-                                      of the label with key topologyKey matches that of any
-                                      node on which any of the selected pods is running. Empty
-                                      topologyKey is not allowed.
-                                    type: string
-                                required:
-                                - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                      type: object
-                    resources:
-                      description: If specified, the container's resources.
-                      items:
-                        description: The pod this Resource is used to specify the requests and limits for
-                          a certain container based on the name.
-                        properties:
-                          container:
-                            description: The name of the container
-                            type: string
-                          limits:
-                            properties:
-                              cpu:
-                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                                type: string
-                              memory:
-                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                                type: string
-                            type: object
-                          requests:
-                            properties:
-                              cpu:
-                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                                type: string
-                              memory:
-                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                                type: string
-                            type: object
-                        type: object
-                      type: array
-              services:
-                description: A mapping of service name to override
-                type: array
-                items:
-                  type: object
-                  properties:
-                    name:
-                      description: The name of the service
-                      type: string
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: Labels overrides labels for the service
-                      type: object
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations overrides labels for the service
-                      type: object
-                    selector:
-                      additionalProperties:
-                        type: string
-                      description: Selector overrides selector for the service
-                      type: object
-              podDisruptionBudgets:
-                description: A mapping of podDisruptionBudget name to override
-                type: array
-                items:
-                  type: object
-                  properties:
-                    name:
-                      description: The name of the podDisruptionBudget
-                      type: string
-                    minAvailable:
-                      anyOf:
-                        - type: integer
-                        - type: string
-                      description: An eviction is allowed if at least "minAvailable" pods selected by "selector" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying "100%".
-                      x-kubernetes-int-or-string: true
-              ingress:
-                description: The ingress configuration for Knative Serving
-                properties:
-                  contour:
-                    description: Contour settings
-                    properties:
-                      enabled:
-                        type: boolean
-                    type: object
-                  istio:
-                    description: Istio settings
-                    properties:
-                      enabled:
-                        type: boolean
-                      knative-ingress-gateway:
-                        description: A means to override the knative-ingress-gateway
-                        properties:
-                          selector:
-                            additionalProperties:
-                              type: string
-                            description: The selector for the ingress-gateway.
-                            type: object
-                          servers:
-                            description: A list of server specifications.
-                            items:
-                              properties:
-                                hosts:
-                                  description: One or more hosts exposed by this gateway.
-                                  items:
-                                    format: string
-                                    type: string
-                                  type: array
-                                port:
-                                  properties:
-                                    name:
-                                      description: Label assigned to the port.
-                                      format: string
-                                      type: string
-                                    number:
-                                      description: A valid non-negative integer port number.
-                                      type: integer
-                                    target_port:
-                                      description: A valid non-negative integer target port number.
-                                      type: integer
-                                    protocol:
-                                      description: The protocol exposed on the port.
-                                      format: string
-                                      type: string
-                                  type: object
-                              type: object
-                            type: array
-                        type: object
-                      knative-local-gateway:
-                        description: A means to override the knative-local-gateway
-                        properties:
-                          selector:
-                            additionalProperties:
-                              type: string
-                            description: The selector for the ingress-gateway.
-                            type: object
-                          servers:
-                            description: A list of server specifications.
-                            items:
-                              properties:
-                                hosts:
-                                  description: One or more hosts exposed by this gateway.
-                                  items:
-                                    format: string
-                                    type: string
-                                  type: array
-                                port:
-                                  properties:
-                                    name:
-                                      description: Label assigned to the port.
-                                      format: string
-                                      type: string
-                                    number:
-                                      description: A valid non-negative integer port number.
-                                      type: integer
-                                    target_port:
-                                      description: A valid non-negative integer target port number.
-                                      type: integer
-                                    protocol:
-                                      description: The protocol exposed on the port.
-                                      format: string
-                                      type: string
-                                  type: object
-                              type: object
-                            type: array
-                        type: object
-                    type: object
-                  kourier:
-                    description: Kourier settings
-                    properties:
-                      enabled:
-                        type: boolean
-                      service-type:
-                        type: string
-                      service-load-balancer-ip:
-                        type: string
-                      bootstrap-configmap:
-                        type: string
-                      http-port:
-                        type: integer
-                      https-port:
-                        type: integer
-                    type: object
-                type: object
-              security:
-                description: The security configuration for Knative Serving
-                properties:
-                  securityGuard:
-                    description: Security Guard settings
-                    properties:
-                      enabled:
-                        type: boolean
-                    type: object
-                type: object
-              manifests:
-                description: A list of serving manifests, which will be installed
-                  by the operator
-                items:
-                  properties:
-                    URL:
-                      description: The link of the manifest URL
-                      type: string
-                  type: object
-                type: array
-              registry:
-                description: A means to override the corresponding deployment images
-                  in the upstream. This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
-                properties:
-                  default:
-                    description: The default image reference template to use for all
-                      knative images. Takes the form of example-registry.io/custom/path/${NAME}:custom-tag
-                    type: string
-                  imagePullSecrets:
-                    description: A list of secrets to be used when pulling the knative
-                      images. The secret must be created in the same namespace as
-                      the knative-serving deployments, and not the namespace of this
-                      resource.
-                    items:
-                      properties:
-                        name:
-                          description: The name of the secret.
-                          type: string
-                      type: object
-                    type: array
-                  override:
-                    additionalProperties:
-                      type: string
-                    description: A map of a container name or image name to the full
-                      image location of the individual knative image.
-                    type: object
-                type: object
-              version:
-                description: The version of Knative Serving to be installed
-                type: string
-            type: object
-          status:
-            description: Status defines the observed state of KnativeServing
-            properties:
-              conditions:
-                description: The latest available observations of a resource's current
-                  state.
-                items:
-                  properties:
-                    lastTransitionTime:
-                      description: LastTransitionTime is the last time the condition
-                        transitioned from one status to another. We use VolatileTime
-                        in place of metav1.Time to exclude this from creating equality.Semantic
-                        differences (all other things held constant).
-                      type: string
-                    message:
-                      description: A human readable message indicating details about
-                        the transition.
-                      type: string
-                    reason:
-                      description: The reason for the condition's last transition.
-                      type: string
-                    severity:
-                      description: Severity with which to treat failures of this type
-                        of condition. When this is not specified, it defaults to Error.
-                      type: string
-                    status:
-                      description: Status of the condition, one of True, False, Unknown.
-                      type: string
-                    type:
-                      description: Type of condition.
-                      type: string
-                  required:
-                  - type
-                  - status
-                  type: object
-                type: array
-              manifests:
-                description: The list of serving manifests, which have been installed
-                  by the operator
-                items:
-                  type: string
-                type: array
-              observedGeneration:
-                description: The generation last processed by the controller
-                type: integer
-              version:
-                description: The version of the installed release
-                type: string
-            type: object
-        type: object
-    additionalPrinterColumns:
-    - jsonPath: .status.version
-      name: Version
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
-      name: Reason
-      type: string
-  names:
-    kind: KnativeServing
-    listKind: KnativeServingList
-    plural: knativeservings
-    singular: knativeserving
-  scope: Namespaced
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions: ["v1beta1"]
-      clientConfig:
-        service:
-          name: operator-webhook
-          namespace: default
-          path: /resource-conversion
 ---
-# Source: knative/operator/config/crd/bases/operator.knative.dev_knativeeventings.yaml
 # Copyright 2021 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -2464,2335 +17,1538 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: knativeeventings.operator.knative.dev
+  labels:
+    app.kubernetes.io/version: "1.15.1"
+    app.kubernetes.io/name: knative-operator
 spec:
   group: operator.knative.dev
   versions:
-  - name: v1beta1
-    served: true
-    storage: true
-    subresources:
-      status: {}
-    schema:
-      openAPIV3Schema:
-        description: Schema for the knativeeventings API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec defines the desired state of KnativeEventing
-            properties:
-              additionalManifests:
-                description: A list of the additional eventing manifests, which will
-                  be installed by the operator
-                items:
-                  properties:
-                    URL:
-                      description: The link of the additional manifest URL
-                      type: string
-                  type: object
-                type: array
-              config:
-                additionalProperties:
+    - name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: Schema for the knativeeventings API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired state of KnativeEventing
+              properties:
+                additionalManifests:
+                  description: A list of the additional eventing manifests, which will be installed by the operator
+                  items:
+                    properties:
+                      URL:
+                        description: The link of the additional manifest URL
+                        type: string
+                    type: object
+                  type: array
+                config:
                   additionalProperties:
-                    type: string
-                  type: object
-                description: A means to override the corresponding entries in the
-                  upstream configmaps
-                type: object
-              defaultBrokerClass:
-                description: The default broker type to use for the brokers Knative
-                  creates. If no value is provided, MTChannelBasedBroker will be used.
-                type: string
-              high-availability:
-                description: Allows specification of HA control plane
-                properties:
-                  replicas:
-                    description: The number of replicas that HA parts of the control
-                      plane will be scaled to
-                    minimum: 0
-                    type: integer
-                type: object
-              workloads:
-                description: A mapping of deployment or statefulset name to override
-                type: array
-                items:
-                  type: object
-                  properties:
-                    name:
-                      description: The name of the deployment
-                      type: string
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: Labels overrides labels for the deployment and its template.
-                      type: object
-                    livenessProbes:
-                      description: LivenessProbes overrides liveness probes for the
-                        containers.
-                      items:
-                        description: ProbesRequirementsOverride enables the user to
-                          override any container's env vars.
-                        properties:
-                          container:
-                            description: The container name
-                            type: string
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully upon probe failure. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and
-                              the time when the processes are forcibly halted with
-                              a kill signal. Set this value longer than the expected
-                              cleanup time for your process. If this value is nil,
-                              the pod's terminationGracePeriodSeconds will be used.
-                              Otherwise, this value overrides the value provided by
-                              the pod spec. Value must be non-negative integer. The
-                              value zero indicates stop immediately via the kill signal
-                              (no opportunity to shut down). This is a beta field
-                              and requires enabling ProbeTerminationGracePeriod feature
-                              gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                              is used if unset.
-                            format: int64
-                            type: integer
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                            times out. Defaults to 1 second. Minimum value is 1.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        required:
-                          - container
-                        type: object
-                      type: array
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations overrides labels for the deployment and its template.
-                      type: object
-                    env:
-                      description: Env overrides env vars for the containers.
-                      items:
-                        properties:
-                          container:
-                            description: The container name
-                            type: string
-                          envVars:
-                            description: The desired EnvVarRequirements
-                            items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
-                              properties:
-                                name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
-                                  type: string
-                                value:
-                                  description: 'Variable references $(VAR_NAME) are
-                                    expanded using the previously defined environment
-                                    variables in the container and any service environment
-                                    variables. If a variable cannot be resolved, the
-                                    reference in the input string will be unchanged.
-                                    Double $$ are reduced to a single $, which allows
-                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                    will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Defaults
-                                    to "".'
-                                  type: string
-                                valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
-                                  properties:
-                                    configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
-                                      properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                        - key
-                                      type: object
-                                    fieldRef:
-                                      description: 'Selects a field of the pod: supports
-                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                        spec.serviceAccountName, status.hostIP, status.podIP,
-                                        status.podIPs.'
-                                      properties:
-                                        apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
-                                          type: string
-                                        fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
-                                          type: string
-                                      required:
-                                        - fieldPath
-                                      type: object
-                                    resourceFieldRef:
-                                      description: 'Selects a resource of the container:
-                                        only resources limits and requests (limits.cpu,
-                                        limits.memory, limits.ephemeral-storage, requests.cpu,
-                                        requests.memory and requests.ephemeral-storage)
-                                        are currently supported.'
-                                      properties:
-                                        containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          description: 'Required: resource to select'
-                                          type: string
-                                      required:
-                                        - resource
-                                      type: object
-                                    secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                        - key
-                                      type: object
-                                  type: object
-                              required:
-                                - name
-                              type: object
-                            type: array
-                        required:
-                          - container
-                        type: object
-                      type: array
-                    replicas:
-                      description: The number of replicas that HA parts of the control plane will be scaled to
-                      type: integer
-                      minimum: 0
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: NodeSelector overrides nodeSelector for the deployment.
-                      type: object
-                    readinessProbes:
-                      description: ReadinessProbes overrides readiness probes for
-                        the containers.
-                      items:
-                        description: ProbesRequirementsOverride enables the user to
-                          override any container's env vars.
-                        properties:
-                          container:
-                            description: The container name
-                            type: string
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully upon probe failure. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and
-                              the time when the processes are forcibly halted with
-                              a kill signal. Set this value longer than the expected
-                              cleanup time for your process. If this value is nil,
-                              the pod's terminationGracePeriodSeconds will be used.
-                              Otherwise, this value overrides the value provided by
-                              the pod spec. Value must be non-negative integer. The
-                              value zero indicates stop immediately via the kill signal
-                              (no opportunity to shut down). This is a beta field
-                              and requires enabling ProbeTerminationGracePeriod feature
-                              gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                              is used if unset.
-                            format: int64
-                            type: integer
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                            times out. Defaults to 1 second. Minimum value is 1.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        required:
-                          - container
-                        type: object
-                      type: array
-                    tolerations:
-                      description: If specified, the pod's tolerations.
-                      items:
-                        description: The pod this Toleration is attached to tolerates any
-                          taint that matches the triple <key,value,effect> using the matching
-                          operator <operator>.
-                        properties:
-                          effect:
-                            description: Effect indicates the taint effect to match. Empty
-                              means match all taint effects. When specified, allowed values
-                              are NoSchedule, PreferNoSchedule and NoExecute.
-                            type: string
-                          key:
-                            description: Key is the taint key that the toleration applies
-                              to. Empty means match all taint keys. If the key is empty, operator
-                              must be Exists; this combination means to match all values and
-                              all keys.
-                            type: string
-                          operator:
-                            description: Operator represents a key's relationship to the value.
-                              Valid operators are Exists and Equal. Defaults to Equal. Exists
-                              is equivalent to wildcard for value, so that a pod can tolerate
-                              all taints of a particular category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the
-                              toleration (which must be of effect NoExecute, otherwise this
-                              field is ignored) tolerates the taint. By default, it is not
-                              set, which means tolerate the taint forever (do not evict).
-                              Zero and negative values will be treated as 0 (evict immediately)
-                              by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches to.
-                              If the operator is Exists, the value should be empty, otherwise
-                              just a regular string.
-                            type: string
-                        type: object
-                      type: array
-                    hostNetwork:
-                      description: Use the host's network namespace if true. Make sure to
-                        understand the security implications if you want to enable it. When
-                        hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet
-                        automatically.
-                      type: boolean
-                    topologySpreadConstraints:
-                      description: If specified, the pod's topology spread constraints.
-                      items:
-                        description: TopologySpreadConstraint specifies how to spread matching
-                          pods among the given topology.
-                        properties:
-                          labelSelector:
-                            description: LabelSelector is used to find matching pods. Pods
-                              that match this label selector are counted to determine the
-                              number of pods in their corresponding topology domain.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that relates
-                                    the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In, NotIn,
-                                        Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists or
-                                        DoesNotExist, the values array must be empty. This
-                                        array is replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field is
-                                  "key", the operator is "In", and the values array contains
-                                  only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          maxSkew:
-                            description: 'MaxSkew describes the degree to which pods may
-                              be unevenly distributed. It''s the maximum permitted difference
-                              between the number of matching pods in any two topology domains
-                              of a given topology type. For example, in a 3-zone cluster,
-                              MaxSkew is set to 1, and pods with the same labelSelector
-                              spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3
-                              to become 1/1/1; scheduling it onto zone1(zone2) would make
-                              the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). -
-                              if MaxSkew is 2, incoming pod can be scheduled onto any zone.
-                              It''s a required field. Default value is 1 and 0 is not allowed.'
-                            format: int32
-                            type: integer
-                          topologyKey:
-                            description: TopologyKey is the key of node labels. Nodes that
-                              have a label with this key and identical values are considered
-                              to be in the same topology. We consider each <key, value>
-                              as a "bucket", and try to put balanced number of pods into
-                              each bucket. It's a required field.
-                            type: string
-                          whenUnsatisfiable:
-                            description: 'WhenUnsatisfiable indicates how to deal with a
-                              pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
-                              (default) tells the scheduler not to schedule it - ScheduleAnyway
-                              tells the scheduler to still schedule it It''s considered
-                              as "Unsatisfiable" if and only if placing incoming pod on
-                              any topology violates "MaxSkew". For example, in a 3-zone
-                              cluster, MaxSkew is set to 1, and pods with the same labelSelector
-                              spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
-                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod
-                              can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
-                              as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In
-                              other words, the cluster can still be imbalanced, but scheduler
-                              won''t make it *more* imbalanced. It''s a required field.'
-                            type: string
-                        required:
-                        - maxSkew
-                        - topologyKey
-                        - whenUnsatisfiable
-                        type: object
-                      type: array
-                    version:
-                      description: Version the cluster should be on.
-                      type: string
-                    volumeMounts:
-                      description: VolumeMounts allows configuration of additional VolumeMounts
-                        on the output StatefulSet definition. VolumeMounts specified will
-                        be appended to other VolumeMounts in the alertmanager container,
-                        that are generated as a result of StorageSpec objects.
-                      items:
-                        description: VolumeMount describes a mounting of a Volume within
-                          a container.
-                        properties:
-                          mountPath:
-                            description: Path within the container at which the volume should
-                              be mounted.  Must not contain ':'.
-                            type: string
-                          mountPropagation:
-                            description: mountPropagation determines how mounts are propagated
-                              from the host to container and the other way around. When
-                              not set, MountPropagationNone is used. This field is beta
-                              in 1.10.
-                            type: string
-                          name:
-                            description: This must match the Name of a Volume.
-                            type: string
-                          readOnly:
-                            description: Mounted read-only if true, read-write otherwise
-                              (false or unspecified). Defaults to false.
-                            type: boolean
-                          subPath:
-                            description: Path within the volume from which the container's
-                              volume should be mounted. Defaults to "" (volume's root).
-                            type: string
-                          subPathExpr:
-                            description: Expanded path within the volume from which the
-                              container's volume should be mounted. Behaves similarly to
-                              SubPath but environment variable references $(VAR_NAME) are
-                              expanded using the container's environment. Defaults to ""
-                              (volume's root). SubPathExpr and SubPath are mutually exclusive.
-                            type: string
-                        required:
-                        - mountPath
-                        - name
-                        type: object
-                      type: array
-                    affinity:
-                      description: If specified, the pod's scheduling constraints.
-                      properties:
-                        nodeAffinity:
-                          description: Describes node affinity scheduling rules for the pod.
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes
-                                that satisfy the affinity expressions specified by this field,
-                                but it may choose a node that violates one or more of the
-                                expressions. The node that is most preferred is the one with
-                                the greatest sum of weights, i.e. for each node that meets
-                                all of the scheduling requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating through
-                                the elements of this field and adding "weight" to the sum
-                                if the node matches the corresponding matchExpressions; the
-                                node(s) with the highest sum are the most preferred.
-                              items:
-                                description: An empty preferred scheduling term matches all
-                                  objects with implicit weight 0 (i.e. it's a no-op). A null
-                                  preferred scheduling term matches no objects (i.e. is also
-                                  a no-op).
-                                properties:
-                                  preference:
-                                    description: A node selector term, associated with the
-                                      corresponding weight.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values. If the
-                                                operator is In or NotIn, the values array
-                                                must be non-empty. If the operator is Exists
-                                                or DoesNotExist, the values array must be
-                                                empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will
-                                                be interpreted as an integer. This array is
-                                                replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values. If the
-                                                operator is In or NotIn, the values array
-                                                must be non-empty. If the operator is Exists
-                                                or DoesNotExist, the values array must be
-                                                empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will
-                                                be interpreted as an integer. This array is
-                                                replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  weight:
-                                    description: Weight associated with matching the corresponding
-                                      nodeSelectorTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - preference
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this
-                                field are not met at scheduling time, the pod will not be
-                                scheduled onto the node. If the affinity requirements specified
-                                by this field cease to be met at some point during pod execution
-                                (e.g. due to an update), the system may or may not try to
-                                eventually evict the pod from its node.
-                              properties:
-                                nodeSelectorTerms:
-                                  description: Required. A list of node selector terms. The
-                                    terms are ORed.
-                                  items:
-                                    description: A null or empty node selector term matches
-                                      no objects. The requirements of them are ANDed. The
-                                      TopologySelectorTerm type implements a subset of the
-                                      NodeSelectorTerm.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values. If the
-                                                operator is In or NotIn, the values array
-                                                must be non-empty. If the operator is Exists
-                                                or DoesNotExist, the values array must be
-                                                empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will
-                                                be interpreted as an integer. This array is
-                                                replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values. If the
-                                                operator is In or NotIn, the values array
-                                                must be non-empty. If the operator is Exists
-                                                or DoesNotExist, the values array must be
-                                                empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will
-                                                be interpreted as an integer. This array is
-                                                replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  type: array
-                              required:
-                                - nodeSelectorTerms
-                              type: object
-                          type: object
-                        podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g. co-locate
-                            this pod in the same node, zone, etc. as some other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes
-                                that satisfy the affinity expressions specified by this field,
-                                but it may choose a node that violates one or more of the
-                                expressions. The node that is most preferred is the one with
-                                the greatest sum of weights, i.e. for each node that meets
-                                all of the scheduling requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating through
-                                the elements of this field and adding "weight" to the sum
-                                if the node has pods which matches the corresponding podAffinityTerm;
-                                the node(s) with the highest sum are the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement is
-                                                a selector that contains values, a key, and
-                                                an operator that relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that the
-                                                    selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If
-                                                    the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array
-                                                    is replaced during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is "In",
-                                              and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey matches
-                                          that of any node on which any of the selected pods
-                                          is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the corresponding
-                                      podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this
-                                field are not met at scheduling time, the pod will not be
-                                scheduled onto the node. If the affinity requirements specified
-                                by this field cease to be met at some point during pod execution
-                                (e.g. due to a pod label update), the system may or may not
-                                try to eventually evict the pod from its node. When there
-                                are multiple elements, the lists of nodes corresponding to
-                                each podAffinityTerm are intersected, i.e. all terms must
-                                be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s)) that
-                                  this pod should be co-located (affinity) or not co-located
-                                  (anti-affinity) with, where co-located is defined as running
-                                  on a node whose value of the label with key <topologyKey>
-                                  matches that of any node on which a pod of the set of pods
-                                  is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources, in
-                                      this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector
-                                          requirements. The requirements are ANDed.
-                                        items:
-                                          description: A label selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string values.
-                                                If the operator is In or NotIn, the values
-                                                array must be non-empty. If the operator is
-                                                Exists or DoesNotExist, the values array must
-                                                be empty. This array is replaced during a
-                                                strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value} pairs.
-                                          A single {key,value} in the matchLabels map is equivalent
-                                          to an element of matchExpressions, whose key field
-                                          is "key", the operator is "In", and the values array
-                                          contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces the
-                                      labelSelector applies to (matches against); null or
-                                      empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods matching
-                                      the labelSelector in the specified namespaces, where
-                                      co-located is defined as running on a node whose value
-                                      of the label with key topologyKey matches that of any
-                                      node on which any of the selected pods is running. Empty
-                                      topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                        podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules (e.g.
-                            avoid putting this pod in the same node, zone, etc. as some other
-                            pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes
-                                that satisfy the anti-affinity expressions specified by this
-                                field, but it may choose a node that violates one or more
-                                of the expressions. The node that is most preferred is the
-                                one with the greatest sum of weights, i.e. for each node that
-                                meets all of the scheduling requirements (resource request,
-                                requiredDuringScheduling anti-affinity expressions, etc.),
-                                compute a sum by iterating through the elements of this field
-                                and adding "weight" to the sum if the node has pods which
-                                matches the corresponding podAffinityTerm; the node(s) with
-                                the highest sum are the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement is
-                                                a selector that contains values, a key, and
-                                                an operator that relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that the
-                                                    selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If
-                                                    the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array
-                                                    is replaced during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is "In",
-                                              and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey matches
-                                          that of any node on which any of the selected pods
-                                          is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the corresponding
-                                      podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified by
-                                this field are not met at scheduling time, the pod will not
-                                be scheduled onto the node. If the anti-affinity requirements
-                                specified by this field cease to be met at some point during
-                                pod execution (e.g. due to a pod label update), the system
-                                may or may not try to eventually evict the pod from its node.
-                                When there are multiple elements, the lists of nodes corresponding
-                                to each podAffinityTerm are intersected, i.e. all terms must
-                                be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s)) that
-                                  this pod should be co-located (affinity) or not co-located
-                                  (anti-affinity) with, where co-located is defined as running
-                                  on a node whose value of the label with key <topologyKey>
-                                  matches that of any node on which a pod of the set of pods
-                                  is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources, in
-                                      this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector
-                                          requirements. The requirements are ANDed.
-                                        items:
-                                          description: A label selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string values.
-                                                If the operator is In or NotIn, the values
-                                                array must be non-empty. If the operator is
-                                                Exists or DoesNotExist, the values array must
-                                                be empty. This array is replaced during a
-                                                strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value} pairs.
-                                          A single {key,value} in the matchLabels map is equivalent
-                                          to an element of matchExpressions, whose key field
-                                          is "key", the operator is "In", and the values array
-                                          contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces the
-                                      labelSelector applies to (matches against); null or
-                                      empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods matching
-                                      the labelSelector in the specified namespaces, where
-                                      co-located is defined as running on a node whose value
-                                      of the label with key topologyKey matches that of any
-                                      node on which any of the selected pods is running. Empty
-                                      topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                      type: object
-                    resources:
-                      description: If specified, the container's resources.
-                      items:
-                        description: The pod this Resource is used to specify the requests and limits for
-                          a certain container based on the name.
-                        properties:
-                          container:
-                            description: The name of the container
-                            type: string
-                          limits:
-                            properties:
-                              cpu:
-                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                                type: string
-                              memory:
-                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                                type: string
-                            type: object
-                          requests:
-                            properties:
-                              cpu:
-                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                                type: string
-                              memory:
-                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                                type: string
-                            type: object
-                        type: object
-                      type: array
-              deployments:
-                description: A mapping of deployment name to override
-                type: array
-                items:
-                  type: object
-                  properties:
-                    name:
-                      description: The name of the deployment
-                      type: string
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: Labels overrides labels for the deployment and its template.
-                      type: object
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations overrides labels for the deployment and its template.
-                      type: object
-                    env:
-                      description: Env overrides env vars for the containers.
-                      items:
-                        properties:
-                          container:
-                            description: The container name
-                            type: string
-                          envVars:
-                            description: The desired EnvVarRequirements
-                            items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
-                              properties:
-                                name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
-                                  type: string
-                                value:
-                                  description: 'Variable references $(VAR_NAME) are
-                                    expanded using the previously defined environment
-                                    variables in the container and any service environment
-                                    variables. If a variable cannot be resolved, the
-                                    reference in the input string will be unchanged.
-                                    Double $$ are reduced to a single $, which allows
-                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                    will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Defaults
-                                    to "".'
-                                  type: string
-                                valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
-                                  properties:
-                                    configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
-                                      properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                        - key
-                                      type: object
-                                    fieldRef:
-                                      description: 'Selects a field of the pod: supports
-                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                        spec.serviceAccountName, status.hostIP, status.podIP,
-                                        status.podIPs.'
-                                      properties:
-                                        apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
-                                          type: string
-                                        fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
-                                          type: string
-                                      required:
-                                        - fieldPath
-                                      type: object
-                                    resourceFieldRef:
-                                      description: 'Selects a resource of the container:
-                                        only resources limits and requests (limits.cpu,
-                                        limits.memory, limits.ephemeral-storage, requests.cpu,
-                                        requests.memory and requests.ephemeral-storage)
-                                        are currently supported.'
-                                      properties:
-                                        containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          description: 'Required: resource to select'
-                                          type: string
-                                      required:
-                                        - resource
-                                      type: object
-                                    secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                        - key
-                                      type: object
-                                  type: object
-                              required:
-                                - name
-                              type: object
-                            type: array
-                        required:
-                          - container
-                        type: object
-                      type: array
-                    livenessProbes:
-                      description: LivenessProbes overrides liveness probes for the
-                        containers.
-                      items:
-                        description: ProbesRequirementsOverride enables the user to
-                          override any container's env vars.
-                        properties:
-                          container:
-                            description: The container name
-                            type: string
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully upon probe failure. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and
-                              the time when the processes are forcibly halted with
-                              a kill signal. Set this value longer than the expected
-                              cleanup time for your process. If this value is nil,
-                              the pod's terminationGracePeriodSeconds will be used.
-                              Otherwise, this value overrides the value provided by
-                              the pod spec. Value must be non-negative integer. The
-                              value zero indicates stop immediately via the kill signal
-                              (no opportunity to shut down). This is a beta field
-                              and requires enabling ProbeTerminationGracePeriod feature
-                              gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                              is used if unset.
-                            format: int64
-                            type: integer
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                            times out. Defaults to 1 second. Minimum value is 1.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        required:
-                          - container
-                        type: object
-                      type: array
-                    replicas:
-                      description: The number of replicas that HA parts of the control plane will be scaled to
-                      type: integer
-                      minimum: 0
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: NodeSelector overrides nodeSelector for the deployment.
-                      type: object
-                    readinessProbes:
-                      description: ReadinessProbes overrides readiness probes for
-                        the containers.
-                      items:
-                        description: ProbesRequirementsOverride enables the user to
-                          override any container's env vars.
-                        properties:
-                          container:
-                            description: The container name
-                            type: string
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully upon probe failure. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and
-                              the time when the processes are forcibly halted with
-                              a kill signal. Set this value longer than the expected
-                              cleanup time for your process. If this value is nil,
-                              the pod's terminationGracePeriodSeconds will be used.
-                              Otherwise, this value overrides the value provided by
-                              the pod spec. Value must be non-negative integer. The
-                              value zero indicates stop immediately via the kill signal
-                              (no opportunity to shut down). This is a beta field
-                              and requires enabling ProbeTerminationGracePeriod feature
-                              gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                              is used if unset.
-                            format: int64
-                            type: integer
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                            times out. Defaults to 1 second. Minimum value is 1.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        required:
-                          - container
-                        type: object
-                      type: array
-                    tolerations:
-                      description: If specified, the pod's tolerations.
-                      items:
-                        description: The pod this Toleration is attached to tolerates any
-                          taint that matches the triple <key,value,effect> using the matching
-                          operator <operator>.
-                        properties:
-                          effect:
-                            description: Effect indicates the taint effect to match. Empty
-                              means match all taint effects. When specified, allowed values
-                              are NoSchedule, PreferNoSchedule and NoExecute.
-                            type: string
-                          key:
-                            description: Key is the taint key that the toleration applies
-                              to. Empty means match all taint keys. If the key is empty, operator
-                              must be Exists; this combination means to match all values and
-                              all keys.
-                            type: string
-                          operator:
-                            description: Operator represents a key's relationship to the value.
-                              Valid operators are Exists and Equal. Defaults to Equal. Exists
-                              is equivalent to wildcard for value, so that a pod can tolerate
-                              all taints of a particular category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the
-                              toleration (which must be of effect NoExecute, otherwise this
-                              field is ignored) tolerates the taint. By default, it is not
-                              set, which means tolerate the taint forever (do not evict).
-                              Zero and negative values will be treated as 0 (evict immediately)
-                              by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches to.
-                              If the operator is Exists, the value should be empty, otherwise
-                              just a regular string.
-                            type: string
-                        type: object
-                      type: array
-                    hostNetwork:
-                      description: Use the host's network namespace if true. Make sure to
-                        understand the security implications if you want to enable it. When
-                        hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet
-                        automatically.
-                      type: boolean
-                    topologySpreadConstraints:
-                      description: If specified, the pod's topology spread constraints.
-                      items:
-                        description: TopologySpreadConstraint specifies how to spread matching
-                          pods among the given topology.
-                        properties:
-                          labelSelector:
-                            description: LabelSelector is used to find matching pods. Pods
-                              that match this label selector are counted to determine the
-                              number of pods in their corresponding topology domain.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that relates
-                                    the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In, NotIn,
-                                        Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists or
-                                        DoesNotExist, the values array must be empty. This
-                                        array is replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field is
-                                  "key", the operator is "In", and the values array contains
-                                  only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          maxSkew:
-                            description: 'MaxSkew describes the degree to which pods may
-                              be unevenly distributed. It''s the maximum permitted difference
-                              between the number of matching pods in any two topology domains
-                              of a given topology type. For example, in a 3-zone cluster,
-                              MaxSkew is set to 1, and pods with the same labelSelector
-                              spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3
-                              to become 1/1/1; scheduling it onto zone1(zone2) would make
-                              the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). -
-                              if MaxSkew is 2, incoming pod can be scheduled onto any zone.
-                              It''s a required field. Default value is 1 and 0 is not allowed.'
-                            format: int32
-                            type: integer
-                          topologyKey:
-                            description: TopologyKey is the key of node labels. Nodes that
-                              have a label with this key and identical values are considered
-                              to be in the same topology. We consider each <key, value>
-                              as a "bucket", and try to put balanced number of pods into
-                              each bucket. It's a required field.
-                            type: string
-                          whenUnsatisfiable:
-                            description: 'WhenUnsatisfiable indicates how to deal with a
-                              pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
-                              (default) tells the scheduler not to schedule it - ScheduleAnyway
-                              tells the scheduler to still schedule it It''s considered
-                              as "Unsatisfiable" if and only if placing incoming pod on
-                              any topology violates "MaxSkew". For example, in a 3-zone
-                              cluster, MaxSkew is set to 1, and pods with the same labelSelector
-                              spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
-                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod
-                              can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
-                              as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In
-                              other words, the cluster can still be imbalanced, but scheduler
-                              won''t make it *more* imbalanced. It''s a required field.'
-                            type: string
-                        required:
-                        - maxSkew
-                        - topologyKey
-                        - whenUnsatisfiable
-                        type: object
-                      type: array
-                    affinity:
-                      description: If specified, the pod's scheduling constraints.
-                      properties:
-                        nodeAffinity:
-                          description: Describes node affinity scheduling rules for the pod.
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes
-                                that satisfy the affinity expressions specified by this field,
-                                but it may choose a node that violates one or more of the
-                                expressions. The node that is most preferred is the one with
-                                the greatest sum of weights, i.e. for each node that meets
-                                all of the scheduling requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating through
-                                the elements of this field and adding "weight" to the sum
-                                if the node matches the corresponding matchExpressions; the
-                                node(s) with the highest sum are the most preferred.
-                              items:
-                                description: An empty preferred scheduling term matches all
-                                  objects with implicit weight 0 (i.e. it's a no-op). A null
-                                  preferred scheduling term matches no objects (i.e. is also
-                                  a no-op).
-                                properties:
-                                  preference:
-                                    description: A node selector term, associated with the
-                                      corresponding weight.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values. If the
-                                                operator is In or NotIn, the values array
-                                                must be non-empty. If the operator is Exists
-                                                or DoesNotExist, the values array must be
-                                                empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will
-                                                be interpreted as an integer. This array is
-                                                replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values. If the
-                                                operator is In or NotIn, the values array
-                                                must be non-empty. If the operator is Exists
-                                                or DoesNotExist, the values array must be
-                                                empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will
-                                                be interpreted as an integer. This array is
-                                                replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  weight:
-                                    description: Weight associated with matching the corresponding
-                                      nodeSelectorTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                - preference
-                                - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this
-                                field are not met at scheduling time, the pod will not be
-                                scheduled onto the node. If the affinity requirements specified
-                                by this field cease to be met at some point during pod execution
-                                (e.g. due to an update), the system may or may not try to
-                                eventually evict the pod from its node.
-                              properties:
-                                nodeSelectorTerms:
-                                  description: Required. A list of node selector terms. The
-                                    terms are ORed.
-                                  items:
-                                    description: A null or empty node selector term matches
-                                      no objects. The requirements of them are ANDed. The
-                                      TopologySelectorTerm type implements a subset of the
-                                      NodeSelectorTerm.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values. If the
-                                                operator is In or NotIn, the values array
-                                                must be non-empty. If the operator is Exists
-                                                or DoesNotExist, the values array must be
-                                                empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will
-                                                be interpreted as an integer. This array is
-                                                replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values. If the
-                                                operator is In or NotIn, the values array
-                                                must be non-empty. If the operator is Exists
-                                                or DoesNotExist, the values array must be
-                                                empty. If the operator is Gt or Lt, the values
-                                                array must have a single element, which will
-                                                be interpreted as an integer. This array is
-                                                replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  type: array
-                              required:
-                              - nodeSelectorTerms
-                              type: object
-                          type: object
-                        podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g. co-locate
-                            this pod in the same node, zone, etc. as some other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes
-                                that satisfy the affinity expressions specified by this field,
-                                but it may choose a node that violates one or more of the
-                                expressions. The node that is most preferred is the one with
-                                the greatest sum of weights, i.e. for each node that meets
-                                all of the scheduling requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating through
-                                the elements of this field and adding "weight" to the sum
-                                if the node has pods which matches the corresponding podAffinityTerm;
-                                the node(s) with the highest sum are the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement is
-                                                a selector that contains values, a key, and
-                                                an operator that relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that the
-                                                    selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If
-                                                    the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array
-                                                    is replaced during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is "In",
-                                              and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey matches
-                                          that of any node on which any of the selected pods
-                                          is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                    - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the corresponding
-                                      podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                - podAffinityTerm
-                                - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by this
-                                field are not met at scheduling time, the pod will not be
-                                scheduled onto the node. If the affinity requirements specified
-                                by this field cease to be met at some point during pod execution
-                                (e.g. due to a pod label update), the system may or may not
-                                try to eventually evict the pod from its node. When there
-                                are multiple elements, the lists of nodes corresponding to
-                                each podAffinityTerm are intersected, i.e. all terms must
-                                be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s)) that
-                                  this pod should be co-located (affinity) or not co-located
-                                  (anti-affinity) with, where co-located is defined as running
-                                  on a node whose value of the label with key <topologyKey>
-                                  matches that of any node on which a pod of the set of pods
-                                  is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources, in
-                                      this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector
-                                          requirements. The requirements are ANDed.
-                                        items:
-                                          description: A label selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string values.
-                                                If the operator is In or NotIn, the values
-                                                array must be non-empty. If the operator is
-                                                Exists or DoesNotExist, the values array must
-                                                be empty. This array is replaced during a
-                                                strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value} pairs.
-                                          A single {key,value} in the matchLabels map is equivalent
-                                          to an element of matchExpressions, whose key field
-                                          is "key", the operator is "In", and the values array
-                                          contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces the
-                                      labelSelector applies to (matches against); null or
-                                      empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods matching
-                                      the labelSelector in the specified namespaces, where
-                                      co-located is defined as running on a node whose value
-                                      of the label with key topologyKey matches that of any
-                                      node on which any of the selected pods is running. Empty
-                                      topologyKey is not allowed.
-                                    type: string
-                                required:
-                                - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                        podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules (e.g.
-                            avoid putting this pod in the same node, zone, etc. as some other
-                            pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods to nodes
-                                that satisfy the anti-affinity expressions specified by this
-                                field, but it may choose a node that violates one or more
-                                of the expressions. The node that is most preferred is the
-                                one with the greatest sum of weights, i.e. for each node that
-                                meets all of the scheduling requirements (resource request,
-                                requiredDuringScheduling anti-affinity expressions, etc.),
-                                compute a sum by iterating through the elements of this field
-                                and adding "weight" to the sum if the node has pods which
-                                matches the corresponding podAffinityTerm; the node(s) with
-                                the highest sum are the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list of label
-                                              selector requirements. The requirements are
-                                              ANDed.
-                                            items:
-                                              description: A label selector requirement is
-                                                a selector that contains values, a key, and
-                                                an operator that relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key that the
-                                                    selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a key's
-                                                    relationship to a set of values. Valid
-                                                    operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of string
-                                                    values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If
-                                                    the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array
-                                                    is replaced during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator is "In",
-                                              and the values array contains only "value".
-                                              The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the pods
-                                          matching the labelSelector in the specified namespaces,
-                                          where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey matches
-                                          that of any node on which any of the selected pods
-                                          is running. Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                    - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the corresponding
-                                      podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                - podAffinityTerm
-                                - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified by
-                                this field are not met at scheduling time, the pod will not
-                                be scheduled onto the node. If the anti-affinity requirements
-                                specified by this field cease to be met at some point during
-                                pod execution (e.g. due to a pod label update), the system
-                                may or may not try to eventually evict the pod from its node.
-                                When there are multiple elements, the lists of nodes corresponding
-                                to each podAffinityTerm are intersected, i.e. all terms must
-                                be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s)) that
-                                  this pod should be co-located (affinity) or not co-located
-                                  (anti-affinity) with, where co-located is defined as running
-                                  on a node whose value of the label with key <topologyKey>
-                                  matches that of any node on which a pod of the set of pods
-                                  is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources, in
-                                      this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector
-                                          requirements. The requirements are ANDed.
-                                        items:
-                                          description: A label selector requirement is a selector
-                                            that contains values, a key, and an operator that
-                                            relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's relationship
-                                                to a set of values. Valid operators are In,
-                                                NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string values.
-                                                If the operator is In or NotIn, the values
-                                                array must be non-empty. If the operator is
-                                                Exists or DoesNotExist, the values array must
-                                                be empty. This array is replaced during a
-                                                strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value} pairs.
-                                          A single {key,value} in the matchLabels map is equivalent
-                                          to an element of matchExpressions, whose key field
-                                          is "key", the operator is "In", and the values array
-                                          contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces the
-                                      labelSelector applies to (matches against); null or
-                                      empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods matching
-                                      the labelSelector in the specified namespaces, where
-                                      co-located is defined as running on a node whose value
-                                      of the label with key topologyKey matches that of any
-                                      node on which any of the selected pods is running. Empty
-                                      topologyKey is not allowed.
-                                    type: string
-                                required:
-                                - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                      type: object
-                    resources:
-                      description: If specified, the container's resources.
-                      items:
-                        description: The pod this Resource is used to specify the requests and limits for
-                          a certain container based on the name.
-                        properties:
-                          container:
-                            description: The name of the container
-                            type: string
-                          limits:
-                            properties:
-                              cpu:
-                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                                type: string
-                              memory:
-                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                                type: string
-                            type: object
-                          requests:
-                            properties:
-                              cpu:
-                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                                type: string
-                              memory:
-                                pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
-                                type: string
-                            type: object
-                        type: object
-                      type: array
-              services:
-                description: A mapping of service name to override
-                type: array
-                items:
-                  type: object
-                  properties:
-                    name:
-                      description: The name of the service
-                      type: string
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: Labels overrides labels for the service
-                      type: object
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations overrides labels for the service
-                      type: object
-                    selector:
-                      additionalProperties:
-                        type: string
-                      description: Selector overrides selector for the service
-                      type: object
-              podDisruptionBudgets:
-                description: A mapping of podDisruptionBudget name to override
-                type: array
-                items:
-                  type: object
-                  properties:
-                    name:
-                      description: The name of the podDisruptionBudget
-                      type: string
-                    minAvailable:
-                      anyOf:
-                        - type: integer
-                        - type: string
-                      description: An eviction is allowed if at least "minAvailable" pods selected by "selector" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying "100%".
-                      x-kubernetes-int-or-string: true
-              source:
-                description: The source configuration for Knative Eventing
-                properties:
-                  ceph:
-                    description: Ceph settings
-                    properties:
-                      enabled:
-                        type: boolean
-                    type: object
-                  github:
-                    description: GitHub settings
-                    properties:
-                      enabled:
-                        type: boolean
-                    type: object
-                  gitlab:
-                    description: GitLab settings
-                    properties:
-                      enabled:
-                        type: boolean
-                    type: object
-                  kafka:
-                    description: Apache Kafka settings
-                    properties:
-                      enabled:
-                        type: boolean
-                    type: object
-                  rabbitmq:
-                    description: RabbitMQ settings
-                    properties:
-                      enabled:
-                        type: boolean
-                    type: object
-                  redis:
-                    description: Redis settings
-                    properties:
-                      enabled:
-                        type: boolean
-                    type: object
-                type: object
-              manifests:
-                description: A list of eventing manifests, which will be installed
-                  by the operator
-                items:
-                  properties:
-                    URL:
-                      description: The link of the manifest URL
-                      type: string
-                  type: object
-                type: array
-              registry:
-                description: A means to override the corresponding deployment images
-                  in the upstream. This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
-                properties:
-                  default:
-                    description: The default image reference template to use for all
-                      knative images. Takes the form of example-registry.io/custom/path/${NAME}:custom-tag
-                    type: string
-                  imagePullSecrets:
-                    description: A list of secrets to be used when pulling the knative
-                      images. The secret must be created in the same namespace as
-                      the knative-eventing deployments, and not the namespace of this
-                      resource.
-                    items:
-                      properties:
-                        name:
-                          description: The name of the secret.
-                          type: string
-                      type: object
-                    type: array
-                  override:
                     additionalProperties:
                       type: string
-                    description: A map of a container name or image name to the full
-                      image location of the individual knative image.
                     type: object
-                type: object
-              sinkBindingSelectionMode:
-                description: Specifies the selection mode for the sinkbinding webhook.
-                  If the value is `inclusion`, only namespaces/objects labelled as
-                  `bindings.knative.dev/include:true` will be considered. If `exclusion`
-                  is selected, only `bindings.knative.dev/exclude:true` label is checked
-                  and these will NOT be considered. The default is `exclusion`.
-                type: string
-              version:
-                description: The version of Knative Eventing to be installed
-                type: string
-            type: object
-          status:
-            properties:
-              conditions:
-                description: The latest available observations of a resource's current
-                  state.
-                items:
-                  properties:
-                    lastTransitionTime:
-                      description: LastTransitionTime is the last time the condition
-                        transitioned from one status to another. We use VolatileTime
-                        in place of metav1.Time to exclude this from creating equality.Semantic
-                        differences (all other things held constant).
-                      type: string
-                    message:
-                      description: A human readable message indicating details about
-                        the transition.
-                      type: string
-                    reason:
-                      description: The reason for the condition's last transition.
-                      type: string
-                    severity:
-                      description: Severity with which to treat failures of this type
-                        of condition. When this is not specified, it defaults to Error.
-                      type: string
-                    status:
-                      description: Status of the condition, one of True, False, Unknown.
-                      type: string
-                    type:
-                      description: Type of condition.
-                      type: string
-                  required:
-                  - type
-                  - status
+                  description: A means to override the corresponding entries in the upstream configmaps
                   type: object
-                type: array
-              manifests:
-                description: The list of eventing manifests, which have been installed
-                  by the operator
-                items:
+                defaultBrokerClass:
+                  description: The default broker type to use for the brokers Knative creates. If no value is provided, MTChannelBasedBroker will be used.
                   type: string
-                type: array
-              observedGeneration:
-                description: The generation last processed by the controller
-                type: integer
-              version:
-                description: The version of the installed release
-                type: string
-            type: object
-        type: object
-    additionalPrinterColumns:
-    - jsonPath: .status.version
-      name: Version
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
-      name: Reason
-      type: string
+                high-availability:
+                  description: Allows specification of HA control plane
+                  properties:
+                    replicas:
+                      description: The number of replicas that HA parts of the control plane will be scaled to
+                      minimum: 0
+                      type: integer
+                  type: object
+                workloads:
+                  description: A mapping of deployment or statefulset name to override
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        description: The name of the deployment
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels overrides labels for the deployment and its template.
+                        type: object
+                      livenessProbes:
+                        description: LivenessProbes overrides liveness probes for the containers.
+                        items:
+                          description: ProbesRequirementsOverride enables the user to override any container's env vars.
+                          properties:
+                            container:
+                              description: The container name
+                              type: string
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          required:
+                            - container
+                          type: object
+                        type: array
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations overrides labels for the deployment and its template.
+                        type: object
+                      env:
+                        description: Env overrides env vars for the containers.
+                        items:
+                          properties:
+                            container:
+                              description: The container name
+                              type: string
+                            envVars:
+                              description: The desired EnvVarRequirements
+                              items:
+                                description: EnvVar represents an environment variable present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select in the specified API version.
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: Specifies the output format of the exposed resources, defaults to "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                          required:
+                            - container
+                          type: object
+                        type: array
+                      replicas:
+                        description: The number of replicas that HA parts of the control plane will be scaled to
+                        type: integer
+                        minimum: 0
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: NodeSelector overrides nodeSelector for the deployment.
+                        type: object
+                      readinessProbes:
+                        description: ReadinessProbes overrides readiness probes for the containers.
+                        items:
+                          description: ProbesRequirementsOverride enables the user to override any container's env vars.
+                          properties:
+                            container:
+                              description: The container name
+                              type: string
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          required:
+                            - container
+                          type: object
+                        type: array
+                      tolerations:
+                        description: If specified, the pod's tolerations.
+                        items:
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                      hostNetwork:
+                        description: Use the host's network namespace if true. Make sure to understand the security implications if you want to enable it. When hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet automatically.
+                        type: boolean
+                      topologySpreadConstraints:
+                        description: If specified, the pod's topology spread constraints.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                            maxSkew:
+                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. It''s the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            topologyKey:
+                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It''s considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                              type: string
+                          required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                          type: object
+                        type: array
+                      version:
+                        description: Version the cluster should be on.
+                        type: string
+                      volumeMounts:
+                        description: VolumeMounts allows configuration of additional VolumeMounts on the output StatefulSet definition. VolumeMounts specified will be appended to other VolumeMounts in the alertmanager container, that are generated as a result of StorageSpec objects.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                              type: string
+                          required:
+                            - mountPath
+                            - name
+                          type: object
+                        type: array
+                      affinity:
+                        description: If specified, the pod's scheduling constraints.
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                  - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      resources:
+                        description: If specified, the container's resources.
+                        items:
+                          description: The pod this Resource is used to specify the requests and limits for a certain container based on the name.
+                          properties:
+                            container:
+                              description: The name of the container
+                              type: string
+                            limits:
+                              properties:
+                                cpu:
+                                  pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                  type: string
+                                memory:
+                                  pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                  type: string
+                              type: object
+                            requests:
+                              properties:
+                                cpu:
+                                  pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                  type: string
+                                memory:
+                                  pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
+                deployments:
+                  description: A mapping of deployment name to override
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        description: The name of the deployment
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels overrides labels for the deployment and its template.
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations overrides labels for the deployment and its template.
+                        type: object
+                      env:
+                        description: Env overrides env vars for the containers.
+                        items:
+                          properties:
+                            container:
+                              description: The container name
+                              type: string
+                            envVars:
+                              description: The desired EnvVarRequirements
+                              items:
+                                description: EnvVar represents an environment variable present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select in the specified API version.
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: Specifies the output format of the exposed resources, defaults to "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                          required:
+                            - container
+                          type: object
+                        type: array
+                      livenessProbes:
+                        description: LivenessProbes overrides liveness probes for the containers.
+                        items:
+                          description: ProbesRequirementsOverride enables the user to override any container's env vars.
+                          properties:
+                            container:
+                              description: The container name
+                              type: string
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          required:
+                            - container
+                          type: object
+                        type: array
+                      replicas:
+                        description: The number of replicas that HA parts of the control plane will be scaled to
+                        type: integer
+                        minimum: 0
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: NodeSelector overrides nodeSelector for the deployment.
+                        type: object
+                      readinessProbes:
+                        description: ReadinessProbes overrides readiness probes for the containers.
+                        items:
+                          description: ProbesRequirementsOverride enables the user to override any container's env vars.
+                          properties:
+                            container:
+                              description: The container name
+                              type: string
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          required:
+                            - container
+                          type: object
+                        type: array
+                      tolerations:
+                        description: If specified, the pod's tolerations.
+                        items:
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                      hostNetwork:
+                        description: Use the host's network namespace if true. Make sure to understand the security implications if you want to enable it. When hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet automatically.
+                        type: boolean
+                      topologySpreadConstraints:
+                        description: If specified, the pod's topology spread constraints.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                            maxSkew:
+                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. It''s the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            topologyKey:
+                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It''s considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                              type: string
+                          required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                          type: object
+                        type: array
+                      affinity:
+                        description: If specified, the pod's scheduling constraints.
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                  - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      resources:
+                        description: If specified, the container's resources.
+                        items:
+                          description: The pod this Resource is used to specify the requests and limits for a certain container based on the name.
+                          properties:
+                            container:
+                              description: The name of the container
+                              type: string
+                            limits:
+                              properties:
+                                cpu:
+                                  pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                  type: string
+                                memory:
+                                  pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                  type: string
+                              type: object
+                            requests:
+                              properties:
+                                cpu:
+                                  pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                  type: string
+                                memory:
+                                  pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
+                services:
+                  description: A mapping of service name to override
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        description: The name of the service
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels overrides labels for the service
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations overrides labels for the service
+                        type: object
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: Selector overrides selector for the service
+                        type: object
+                podDisruptionBudgets:
+                  description: A mapping of podDisruptionBudget name to override
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        description: The name of the podDisruptionBudget
+                        type: string
+                      minAvailable:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: An eviction is allowed if at least "minAvailable" pods selected by "selector" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying "100%".
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: An eviction is allowed if at most "maxUnavailable" pods selected by "selector" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with "minAvailable".
+                        x-kubernetes-int-or-string: true
+                source:
+                  description: The source configuration for Knative Eventing
+                  properties:
+                    ceph:
+                      description: Ceph settings
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    github:
+                      description: GitHub settings
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    gitlab:
+                      description: GitLab settings
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    kafka:
+                      description: Apache Kafka settings
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    rabbitmq:
+                      description: RabbitMQ settings
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    redis:
+                      description: Redis settings
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                  type: object
+                manifests:
+                  description: A list of eventing manifests, which will be installed by the operator
+                  items:
+                    properties:
+                      URL:
+                        description: The link of the manifest URL
+                        type: string
+                    type: object
+                  type: array
+                registry:
+                  description: A means to override the corresponding deployment images in the upstream. This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
+                  properties:
+                    default:
+                      description: The default image reference template to use for all knative images. Takes the form of example-registry.io/custom/path/${NAME}:custom-tag
+                      type: string
+                    imagePullSecrets:
+                      description: A list of secrets to be used when pulling the knative images. The secret must be created in the same namespace as the knative-eventing deployments, and not the namespace of this resource.
+                      items:
+                        properties:
+                          name:
+                            description: The name of the secret.
+                            type: string
+                        type: object
+                      type: array
+                    override:
+                      additionalProperties:
+                        type: string
+                      description: A map of a container name or image name to the full image location of the individual knative image.
+                      type: object
+                  type: object
+                sinkBindingSelectionMode:
+                  description: Specifies the selection mode for the sinkbinding webhook. If the value is `inclusion`, only namespaces/objects labelled as `bindings.knative.dev/include:true` will be considered. If `exclusion` is selected, only `bindings.knative.dev/exclude:true` label is checked and these will NOT be considered. The default is `exclusion`.
+                  type: string
+                version:
+                  description: The version of Knative Eventing to be installed
+                  type: string
+              type: object
+            status:
+              properties:
+                conditions:
+                  description: The latest available observations of a resource's current state.
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                    required:
+                      - type
+                      - status
+                    type: object
+                  type: array
+                manifests:
+                  description: The list of eventing manifests, which have been installed by the operator
+                  items:
+                    type: string
+                  type: array
+                observedGeneration:
+                  description: The generation last processed by the controller
+                  type: integer
+                version:
+                  description: The version of the installed release
+                  type: string
+              type: object
+          type: object
+      additionalPrinterColumns:
+        - jsonPath: .status.version
+          name: Version
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
   names:
     kind: KnativeEventing
     listKind: KnativeEventingList
@@ -4806,5 +1562,1682 @@ spec:
       clientConfig:
         service:
           name: operator-webhook
-          namespace: default
+          namespace: knative-operator
           path: /resource-conversion
+
+---
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: knativeservings.operator.knative.dev
+  labels:
+    app.kubernetes.io/version: "1.15.1"
+    app.kubernetes.io/name: knative-operator
+spec:
+  group: operator.knative.dev
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: Schema for the knativeservings API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired state of KnativeServing
+              properties:
+                additionalManifests:
+                  description: A list of the additional serving manifests, which will be installed by the operator
+                  items:
+                    properties:
+                      URL:
+                        description: The link of the additional manifest URL
+                        type: string
+                    type: object
+                  type: array
+                config:
+                  additionalProperties:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  description: A means to override the corresponding entries in the upstream configmaps
+                  type: object
+                controller-custom-certs:
+                  description: Enabling the controller to trust registries with self-signed certificates
+                  properties:
+                    name:
+                      description: The name of the ConfigMap or Secret
+                      type: string
+                    type:
+                      description: One of ConfigMap or Secret
+                      enum:
+                        - ConfigMap
+                        - Secret
+                        - ""
+                      type: string
+                  type: object
+                high-availability:
+                  description: Allows specification of HA control plane
+                  properties:
+                    replicas:
+                      description: The number of replicas that HA parts of the control plane will be scaled to
+                      minimum: 0
+                      type: integer
+                  type: object
+                workloads:
+                  description: A mapping of deployment or statefulset name to override
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        description: The name of the deployment
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels overrides labels for the deployment and its template.
+                        type: object
+                      livenessProbes:
+                        description: LivenessProbes overrides liveness probes for the containers.
+                        items:
+                          description: ProbesRequirementsOverride enables the user to override any container's env vars.
+                          properties:
+                            container:
+                              description: The container name
+                              type: string
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          required:
+                            - container
+                          type: object
+                        type: array
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations overrides labels for the deployment and its template.
+                        type: object
+                      env:
+                        description: Env overrides env vars for the containers.
+                        items:
+                          properties:
+                            container:
+                              description: The container name
+                              type: string
+                            envVars:
+                              description: The desired EnvVarRequirements
+                              items:
+                                description: EnvVar represents an environment variable present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select in the specified API version.
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: Specifies the output format of the exposed resources, defaults to "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                          required:
+                            - container
+                          type: object
+                        type: array
+                      replicas:
+                        description: The number of replicas that HA parts of the control plane will be scaled to
+                        type: integer
+                        minimum: 0
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: NodeSelector overrides nodeSelector for the deployment.
+                        type: object
+                      readinessProbes:
+                        description: ReadinessProbes overrides readiness probes for the containers.
+                        items:
+                          description: ProbesRequirementsOverride enables the user to override any container's env vars.
+                          properties:
+                            container:
+                              description: The container name
+                              type: string
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          required:
+                            - container
+                          type: object
+                        type: array
+                      tolerations:
+                        description: If specified, the pod's tolerations.
+                        items:
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                      hostNetwork:
+                        description: Use the host's network namespace if true. Make sure to understand the security implications if you want to enable it. When hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet automatically.
+                        type: boolean
+                      topologySpreadConstraints:
+                        description: If specified, the pod's topology spread constraints.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                            maxSkew:
+                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. It''s the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            topologyKey:
+                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It''s considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                              type: string
+                          required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                          type: object
+                        type: array
+                      version:
+                        description: Version the cluster should be on.
+                        type: string
+                      volumeMounts:
+                        description: VolumeMounts allows configuration of additional VolumeMounts on the output StatefulSet definition. VolumeMounts specified will be appended to other VolumeMounts in the alertmanager container, that are generated as a result of StorageSpec objects.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                              type: string
+                          required:
+                            - mountPath
+                            - name
+                          type: object
+                        type: array
+                      affinity:
+                        description: If specified, the pod's scheduling constraints.
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                  - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      resources:
+                        description: If specified, the container's resources.
+                        items:
+                          description: The pod this Resource is used to specify the requests and limits for a certain container based on the name.
+                          properties:
+                            container:
+                              description: The name of the container
+                              type: string
+                            limits:
+                              properties:
+                                cpu:
+                                  pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                  type: string
+                                memory:
+                                  pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                  type: string
+                              type: object
+                            requests:
+                              properties:
+                                cpu:
+                                  pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                  type: string
+                                memory:
+                                  pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
+                deployments:
+                  description: A mapping of deployment name to override
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        description: The name of the deployment
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels overrides labels for the deployment and its template.
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations overrides labels for the deployment and its template.
+                        type: object
+                      env:
+                        description: Env overrides env vars for the containers.
+                        items:
+                          properties:
+                            container:
+                              description: The container name
+                              type: string
+                            envVars:
+                              description: The desired EnvVarRequirements
+                              items:
+                                description: EnvVar represents an environment variable present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select in the specified API version.
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: Specifies the output format of the exposed resources, defaults to "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                          required:
+                            - container
+                          type: object
+                        type: array
+                      livenessProbes:
+                        description: LivenessProbes overrides liveness probes for the containers.
+                        items:
+                          description: ProbesRequirementsOverride enables the user to override any container's env vars.
+                          properties:
+                            container:
+                              description: The container name
+                              type: string
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          required:
+                            - container
+                          type: object
+                        type: array
+                      replicas:
+                        description: The number of replicas that HA parts of the control plane will be scaled to
+                        type: integer
+                        minimum: 0
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: NodeSelector overrides nodeSelector for the deployment.
+                        type: object
+                      readinessProbes:
+                        description: ReadinessProbes overrides readiness probes for the containers.
+                        items:
+                          description: ProbesRequirementsOverride enables the user to override any container's env vars.
+                          properties:
+                            container:
+                              description: The container name
+                              type: string
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          required:
+                            - container
+                          type: object
+                        type: array
+                      tolerations:
+                        description: If specified, the pod's tolerations.
+                        items:
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                      hostNetwork:
+                        description: Use the host's network namespace if true. Make sure to understand the security implications if you want to enable it. When hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet automatically.
+                        type: boolean
+                      topologySpreadConstraints:
+                        description: If specified, the pod's topology spread constraints.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                            maxSkew:
+                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. It''s the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            topologyKey:
+                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It''s considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                              type: string
+                          required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                          type: object
+                        type: array
+                      affinity:
+                        description: If specified, the pod's scheduling constraints.
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                  - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                        - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      resources:
+                        description: If specified, the container's resources.
+                        items:
+                          description: The pod this Resource is used to specify the requests and limits for a certain container based on the name.
+                          properties:
+                            container:
+                              description: The name of the container
+                              type: string
+                            limits:
+                              properties:
+                                cpu:
+                                  pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                  type: string
+                                memory:
+                                  pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                  type: string
+                              type: object
+                            requests:
+                              properties:
+                                cpu:
+                                  pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                  type: string
+                                memory:
+                                  pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
+                services:
+                  description: A mapping of service name to override
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        description: The name of the service
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels overrides labels for the service
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations overrides labels for the service
+                        type: object
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: Selector overrides selector for the service
+                        type: object
+                podDisruptionBudgets:
+                  description: A mapping of podDisruptionBudget name to override
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        description: The name of the podDisruptionBudget
+                        type: string
+                      minAvailable:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: An eviction is allowed if at least "minAvailable" pods selected by "selector" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying "100%".
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: An eviction is allowed if at most "maxUnavailable" pods selected by "selector" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with "minAvailable".
+                        x-kubernetes-int-or-string: true
+                ingress:
+                  description: The ingress configuration for Knative Serving
+                  properties:
+                    contour:
+                      description: Contour settings
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                    istio:
+                      description: Istio settings
+                      properties:
+                        enabled:
+                          type: boolean
+                        knative-ingress-gateway:
+                          description: A means to override the knative-ingress-gateway
+                          properties:
+                            selector:
+                              additionalProperties:
+                                type: string
+                              description: The selector for the ingress-gateway.
+                              type: object
+                            servers:
+                              description: A list of server specifications.
+                              items:
+                                properties:
+                                  hosts:
+                                    description: One or more hosts exposed by this gateway.
+                                    items:
+                                      format: string
+                                      type: string
+                                    type: array
+                                  port:
+                                    properties:
+                                      name:
+                                        description: Label assigned to the port.
+                                        format: string
+                                        type: string
+                                      number:
+                                        description: A valid non-negative integer port number.
+                                        type: integer
+                                      target_port:
+                                        description: A valid non-negative integer target port number.
+                                        type: integer
+                                      protocol:
+                                        description: The protocol exposed on the port.
+                                        format: string
+                                        type: string
+                                    type: object
+                                  tls:
+                                    properties:
+                                      mode:
+                                        description: TLS mode can be SIMPLE, MUTUAL, ISTIO_MUTUAL.
+                                        format: string
+                                        type: string
+                                      credentialName:
+                                        description: TLS certificate name.
+                                        format: string
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                        knative-local-gateway:
+                          description: A means to override the knative-local-gateway
+                          properties:
+                            selector:
+                              additionalProperties:
+                                type: string
+                              description: The selector for the ingress-gateway.
+                              type: object
+                            servers:
+                              description: A list of server specifications.
+                              items:
+                                properties:
+                                  hosts:
+                                    description: One or more hosts exposed by this gateway.
+                                    items:
+                                      format: string
+                                      type: string
+                                    type: array
+                                  port:
+                                    properties:
+                                      name:
+                                        description: Label assigned to the port.
+                                        format: string
+                                        type: string
+                                      number:
+                                        description: A valid non-negative integer port number.
+                                        type: integer
+                                      target_port:
+                                        description: A valid non-negative integer target port number.
+                                        type: integer
+                                      protocol:
+                                        description: The protocol exposed on the port.
+                                        format: string
+                                        type: string
+                                    type: object
+                                  tls:
+                                    properties:
+                                      mode:
+                                        description: TLS mode can be SIMPLE, MUTUAL, ISTIO_MUTUAL.
+                                        format: string
+                                        type: string
+                                      credentialName:
+                                        description: TLS certificate name.
+                                        format: string
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    kourier:
+                      description: Kourier settings
+                      properties:
+                        enabled:
+                          type: boolean
+                        service-type:
+                          type: string
+                        service-load-balancer-ip:
+                          type: string
+                        bootstrap-configmap:
+                          type: string
+                        http-port:
+                          type: integer
+                        https-port:
+                          type: integer
+                      type: object
+                  type: object
+                security:
+                  description: The security configuration for Knative Serving
+                  properties:
+                    securityGuard:
+                      description: Security Guard settings
+                      properties:
+                        enabled:
+                          type: boolean
+                      type: object
+                  type: object
+                manifests:
+                  description: A list of serving manifests, which will be installed by the operator
+                  items:
+                    properties:
+                      URL:
+                        description: The link of the manifest URL
+                        type: string
+                    type: object
+                  type: array
+                registry:
+                  description: A means to override the corresponding deployment images in the upstream. This affects both apps/v1.Deployment and caching.internal.knative.dev/v1alpha1.Image.
+                  properties:
+                    default:
+                      description: The default image reference template to use for all knative images. Takes the form of example-registry.io/custom/path/${NAME}:custom-tag
+                      type: string
+                    imagePullSecrets:
+                      description: A list of secrets to be used when pulling the knative images. The secret must be created in the same namespace as the knative-serving deployments, and not the namespace of this resource.
+                      items:
+                        properties:
+                          name:
+                            description: The name of the secret.
+                            type: string
+                        type: object
+                      type: array
+                    override:
+                      additionalProperties:
+                        type: string
+                      description: A map of a container name or image name to the full image location of the individual knative image.
+                      type: object
+                  type: object
+                version:
+                  description: The version of Knative Serving to be installed
+                  type: string
+              type: object
+            status:
+              description: Status defines the observed state of KnativeServing
+              properties:
+                conditions:
+                  description: The latest available observations of a resource's current state.
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                    required:
+                      - type
+                      - status
+                    type: object
+                  type: array
+                manifests:
+                  description: The list of serving manifests, which have been installed by the operator
+                  items:
+                    type: string
+                  type: array
+                observedGeneration:
+                  description: The generation last processed by the controller
+                  type: integer
+                version:
+                  description: The version of the installed release
+                  type: string
+              type: object
+          type: object
+      additionalPrinterColumns:
+        - jsonPath: .status.version
+          name: Version
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Reason
+          type: string
+  names:
+    kind: KnativeServing
+    listKind: KnativeServingList
+    plural: knativeservings
+    singular: knativeserving
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1beta1"]
+      clientConfig:
+        service:
+          name: operator-webhook
+          namespace: knative-operator
+          path: /resource-conversion
+

--- a/charms/knative-operator/src/manifests/secret_manifests.yaml.j2
+++ b/charms/knative-operator/src/manifests/secret_manifests.yaml.j2
@@ -20,7 +20,7 @@ metadata:
   namespace: {{ namespace }}
   labels:
     app.kubernetes.io/component: operator-webhook
-    operator.knative.dev/release: "v1.12.4"
-    app.kubernetes.io/version: "v1.12.4"
+    operator.knative.dev/release: "v1.15.2"
+    app.kubernetes.io/version: "v1.15.2"
     app.kubernetes.io/name: knative-operator
 # The data is populated at install time.

--- a/charms/knative-serving/config.yaml
+++ b/charms/knative-serving/config.yaml
@@ -65,3 +65,10 @@ options:
     default: ""
     description: The value of NO_PROXY environment variable in the serving controller.
     type: string
+  ingress-class:
+    default: ""
+    description: |
+      The ingress class used by Knative Serving.  This should be set at deploy time - changing ingress=class during runtime has undefined behaviour within Knative Serving.
+      If left unset, Knative Serving's default value will be used.  Other valid options include:
+      - "gateway-api.ingress.networking.knative.dev": to use the Kubernetes Gateway API
+    type: string

--- a/charms/knative-serving/config.yaml
+++ b/charms/knative-serving/config.yaml
@@ -3,7 +3,7 @@
 
 options:
   version:
-    default: "1.12.4"
+    default: "1.15.0"
     description: Version of knative-serving component.
     type: string
   namespace:

--- a/charms/knative-serving/src/charm.py
+++ b/charms/knative-serving/src/charm.py
@@ -181,6 +181,8 @@ class KnativeServingCharm(CharmBase):
             context.update(self._otel_collector_relation_data)
         if self.model.config["queue_sidecar_image"]:
             context.update({"queue_sidecar_image": self.model.config["queue_sidecar_image"]})
+        if self.model.config["ingress-class"]:
+            context.update({"ingress_class": self.model.config["ingress-class"]})
 
         return context
 

--- a/charms/knative-serving/src/manifests/KnativeServing.yaml.j2
+++ b/charms/knative-serving/src/manifests/KnativeServing.yaml.j2
@@ -18,6 +18,7 @@ spec:
       kubernetes.podspec-nodeselector: "enabled"
       kubernetes.podspec-tolerations: "enabled"
     # This is analogous to the config-istio configmap
+    {% if not ingress_class %}
     istio:
       # TODO
       # To define the external gateway:
@@ -28,9 +29,35 @@ spec:
       # Where local-gateway-namespace is the same as the knative-namespace and istio-namespace is where istio is deployed, in this particular
       # case we know the gateway namespace and the istio namespace will be the same
       local-gateway.{{ serving_namespace }}.knative-local-gateway: "knative-local-gateway.{{ gateway_namespace }}.svc.cluster.local"
+    {% endif %}
     # This is analogous to the config-domain configmap
+    # TODO: defining this gateway config did nothing.  Maybe the operator doesn't support it?
+    {% if ingress_class == 'gateway-api.ingress.networking.knative.dev' %}
+    gateway:
+      # TODO: Make this dynamic
+      external-gateways: |
+        - class: istio
+          gateway: istio-system/istio-ingress-k8s
+          # OPTIONAL - omitting it means it'll take a LB's first address
+          # service: (cant remember if this was namespace/svc or a url)
+          supported-features:
+          - HTTPRouteRequestTimeout
+      local-gateways: |
+        - class: istio
+          gateway: istio-system/istio-ingress-k8s
+          # OPTIONAL - might not be optional for local gateway though
+          # service: (cant remember if this was namespace/svc or a url)
+          supported-features:
+          - HTTPRouteRequestTimeout
+    {% endif %}
     domain:
       {{ domain }}: ""
+    {% if ingress_class %}
+    network:
+      # Setting this tells net-istio to not reconcile things, I think?  If I set this, I don't see any VirtualServices
+      # created for knative services
+      ingress-class: gateway-api.ingress.networking.knative.dev
+    {% endif %}
 {% if otel_collector_svc_name %}
     observability:
       metrics.backend-destination: opencensus

--- a/charms/knative-serving/src/manifests/NetGatewayApi.yaml.j2
+++ b/charms/knative-serving/src/manifests/NetGatewayApi.yaml.j2
@@ -1,0 +1,423 @@
+{% if ingress_class == 'gateway-api.ingress.networking.knative.dev' %}
+
+# This deploys the net-gateway-api for knative serving as defined [here](https://github.com/knative-extensions/net-gateway-api/releases/tag/knative-v1.15.1)
+# TODO: When deploying net-gateway-api, we could remove the net-istio controller/webhook.  Presently, we don't do that.
+
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-gateway-api-admin
+  labels:
+    networking.knative.dev/ingress-provider: net-gateway-api
+    app.kubernetes.io/component: net-gateway-api
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        serving.knative.dev/controller: "true"
+rules: [] # Rules are automatically filled in by the controller manager.
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-gateway-api-core
+  labels:
+    serving.knative.dev/controller: "true"
+    networking.knative.dev/ingress-provider: net-gateway-api
+    app.kubernetes.io/component: net-gateway-api
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+rules:
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes", "referencegrants", "referencepolicies"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gateways"]
+    verbs: ["get", "list", "update", "patch", "watch"]
+
+---
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: net-gateway-api-controller
+  namespace: {{ serving_namespace }}
+  labels:
+    networking.knative.dev/ingress-provider: net-gateway-api
+    app.kubernetes.io/component: net-gateway-api
+    app.kubernetes.io/version: "1.15.1"
+    app.kubernetes.io/name: knative-serving
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: net-gateway-api-controller
+  template:
+    metadata:
+      labels:
+        app: net-gateway-api-controller
+    spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: net-gateway-api-controller
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+      serviceAccountName: controller
+      containers:
+        - name: controller
+          # This is the Go import path for the binary that is containerized
+          # and substituted here.
+          image: gcr.io/knative-releases/knative.dev/net-gateway-api/cmd/controller@sha256:2752100c319a5479b437162e2f3af6cc1815c308a0ea38f6c4e3ef8483d1a7da
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 1000m
+              memory: 1000Mi
+          ports:
+            - name: metrics
+              containerPort: 9090
+            - name: profiling
+              containerPort: 8008
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: METRICS_DOMAIN
+              value: knative.dev/net-gateway-api
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+
+---
+# Copyright 2024 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: net-gateway-api-webhook
+  namespace: {{ serving_namespace }}
+  labels:
+    app.kubernetes.io/component: net-gateway-api
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+    networking.knative.dev/ingress-provider: gateway-api
+spec:
+  selector:
+    matchLabels:
+      app: net-gateway-api-webhook
+      role: net-gateway-api-webhook
+  template:
+    metadata:
+      labels:
+        app: net-gateway-api-webhook
+        role: net-gateway-api-webhook
+        app.kubernetes.io/component: net-gateway-api
+        app.kubernetes.io/name: knative-serving
+        app.kubernetes.io/version: "1.15.1"
+    spec:
+      serviceAccountName: controller
+      containers:
+        - name: webhook
+          # This is the Go import path for the binary that is containerized
+          # and substituted here.
+          image: gcr.io/knative-releases/knative.dev/net-gateway-api/cmd/webhook@sha256:e0c22466c0770fe8decf27a233a12a44e3bf08440a34ae3800e409abce173e4e
+          resources:
+            requests:
+              cpu: 20m
+              memory: 20Mi
+            limits:
+              cpu: 200m
+              memory: 200Mi
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+            - name: METRICS_DOMAIN
+              value: knative.dev/net-gateway-api
+            - name: WEBHOOK_NAME
+              value: net-gateway-api-webhook
+            # If you change WEBHOOK_PORT, you will also need to change the
+            # containerPort "https-webhook" to the same value.
+            - name: WEBHOOK_PORT
+              value: "8443"
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          readinessProbe:
+            periodSeconds: 1
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+            failureThreshold: 3
+          livenessProbe:
+            periodSeconds: 1
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+            failureThreshold: 6
+            initialDelaySeconds: 20
+          ports:
+            - name: metrics
+              containerPort: 9090
+            - name: profiling
+              containerPort: 8008
+            - name: https-webhook
+              containerPort: 8443
+
+---
+# Copyright 2024 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: net-gateway-api-webhook-certs
+  namespace: {{ serving_namespace }}
+  labels:
+    app.kubernetes.io/component: net-gateway-api
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+    networking.knative.dev/ingress-provider: gateway-api
+
+---
+# Copyright 2024 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: net-gateway-api-webhook
+  namespace: {{ serving_namespace }}
+  labels:
+    role: net-gateway-api-webhook
+    app.kubernetes.io/component: net-gateway-api
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+    networking.knative.dev/ingress-provider: gateway-api
+spec:
+  ports:
+    # Define metrics and profiling for them to be accessible within service meshes.
+    - name: http-metrics
+      port: 9090
+      targetPort: metrics
+    - name: http-profiling
+      port: 8008
+      targetPort: profiling
+    - name: https-webhook
+      port: 443
+      targetPort: https-webhook
+  selector:
+    app: net-gateway-api-webhook
+
+---
+# Copyright 2024 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: config.webhook.gateway-api.networking.internal.knative.dev
+  labels:
+    app.kubernetes.io/component: net-gateway-api
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+    networking.knative.dev/ingress-provider: gateway-api
+webhooks:
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: net-gateway-api-webhook
+        namespace: {{ serving_namespace }}
+    failurePolicy: Fail
+    sideEffects: None
+    name: config.webhook.gateway-api.networking.internal.knative.dev
+    objectSelector:
+      matchLabels:
+        app.kubernetes.io/name: knative-serving
+        app.kubernetes.io/component: net-gateway-api
+
+---
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-gateway
+  namespace: {{ serving_namespace }}
+  labels:
+    networking.knative.dev/ingress-provider: net-gateway-api
+    app.kubernetes.io/component: net-gateway-api
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # When configuring Gateways below if 'service' is not provided,
+    # net-gateway-api will use the first address on the Gateway status
+    # for probing. This is useful when the Gateway proxy is off cluster.
+    #
+    # See: https://github.com/knative-extensions/net-gateway-api/issues/665
+
+    # external-gateways defines the Gateway to be used for external traffic
+    external-gateways: |
+      - class: istio
+        gateway: istio-system/knative-gateway
+        service: istio-system/istio-ingressgateway
+        supported-features:
+        - HTTPRouteRequestTimeout
+
+    # local-gateways defines the Gateway to be used for cluster local traffic
+    local-gateways: |
+      - class: istio
+        gateway: istio-system/knative-local-gateway
+        service: istio-system/knative-local-gateway
+        supported-features:
+        - HTTPRouteRequestTimeout
+  external-gateways: |
+    - class: istio
+      gateway: {{ gateway_namespace }}/{{ gateway_name }}
+      # OPTIONAL - omitting it means it'll take a LB's first address
+      # service: (cant remember if this was namespace/svc or a url)
+      supported-features:
+      - HTTPRouteRequestTimeout
+  # TODO: Make a separate local gateway
+  local-gateways: |
+    - class: istio
+      gateway: {{ gateway_namespace }}/{{ gateway_name }}
+      # OPTIONAL - might not be optional for local gateway though
+      # service: (cant remember if this was namespace/svc or a url)
+      supported-features:
+      - HTTPRouteRequestTimeout
+---
+
+{% endif %}


### PR DESCRIPTION
This PR:
* bumps Knative to 0.15
* adds a section in `README.md` describing how you can connect knative to the istio and ingress from `istio-k8s` and `istio-ingress-k8s`
* adds the `ingress_class` configurations and features needed to use knative with the Gateway API 

What doesn't work:
* any charm release CI (that has been disabled because this fork does not have somewhere to release to)

Todo:
* [ ] refactor the integration tests to use istio-k8s and istio-ingress-k8s (I'm open to doing this here, or as a separate issue)

### Testing instructions
There are integration tests here, but they're from the original charm and do not currently use the new istio.  For now, manual testing can be done with the instructions in `README.md`.  
